### PR TITLE
Update the description about upload workbook to Power BI

### DIFF
--- a/powerbi-docs/service-publish-from-excel.md
+++ b/powerbi-docs/service-publish-from-excel.md
@@ -59,7 +59,7 @@ When you choose this option, your workbook will appear in Power BI just like it 
 
 You can’t edit your workbook in when open in Power BI, but if you need to make some changes, you can select **Edit**, and then choose to edit your workbook in Excel Online or open it in Excel on your computer. Any changes you make are saved to the workbook on OneDrive.
 
-When you upload, no dataset is created in Power BI. Your workbook will appear in Reports, in your workspace navigation pane. Workbooks uploaded to Power BI have a special Excel icon, identifying them as Excel workbooks that have been uploaded.
+WWhen you upload a workbook, Power BI will create a corresponding dataset for it. You can use this dataset to create a Power BI report if needed. Your workbook will appear in Workbooks, in your workspace navigation pane. 
 
 Choose this option if you only have data in worksheets, or you have PivotTables and Charts you want to see in Power BI.
 Using Upload from Publish to Power BI in Excel is pretty much the same as using Get Data > File > OneDrive for Business > Connect, Manage and View Excel in Power BI from Power BI in your browser.


### PR DESCRIPTION
Based on the test on the latest version of Power BI Online and Excel 2016, when use the option "Upload your workbook to Power B", Power BI Online will automatically create a dataset for the connected Excel workbook. But the current docs said "no dataset is created in Power BI". This is incorrect description, so i want to update it.