### PR TITLE
Correcting Privacy Level Error

### DIFF
--- a/powerbi-docs/desktop-privacy-levels.md
+++ b/powerbi-docs/desktop-privacy-levels.md
@@ -40,7 +40,7 @@ To configure a data source privacy level, select the data source, then select **
 > 
 
 ## Configure Privacy Levels
-**Privacy Levels** is a setting that is set to **Combine data according to your Privacy Level settings for each source** by default, which means that **Privacy Levels** is not enabled.
+**Privacy Levels** is set to **Combine data according to your Privacy Level settings for each source** by default, which means that **Privacy Levels** are enforced.
 
 | Setting | Description |
 | --- | --- |


### PR DESCRIPTION
Currently, the article incorrectly states that the default setting results in privacy levels being ignored. This edit corrects this.