### PR TITLE
Added link to PubNub doc about whitelisting outbound traffic

### DIFF
--- a/powerbi-docs/service-real-time-streaming.md
+++ b/powerbi-docs/service-real-time-streaming.md
@@ -48,7 +48,7 @@ The only way to visualize a streaming dataset is to add a tile and use the strea
 In practice, streaming datasets and their accompanying streaming visuals are best used in situations when it is critical to minimize the latency between when data is pushed and when it is visualized. In addition, it's best practice to have the data pushed in a format that can be visualized as-is, without any additional aggregations. Examples of data that's ready as-is include temperatures, and pre-calculated averages.
 
 ### PubNub streaming dataset
-With a **PubNub** streaming dataset, the Power BI web client uses the PubNub SDK to read an existing PubNub data stream, and no data is stored by the Power BI service.
+With a **PubNub** streaming dataset, the Power BI web client uses the PubNub SDK to read an existing PubNub data stream, and no data is stored by the Power BI service. Since this call is made from the web client directly, you would have to whitelist traffic to PubNub if you only allow whitelisted outbound traffic from your network. Please refer to the instructions in the support article about [whitelisting outbound traffic for PubNub](https://support.pubnub.com/support/solutions/articles/14000043522-can-i-whitelist-ips-for-pubnub-traffic-).
 
 As with the **streaming dataset**, with the **PubNub streaming dataset** there is no underlying database in Power BI, so you cannot build report visuals against the data that flows in, and cannot take advantage of report functionality such as filtering, Power BI visuals, and so on. As such, the **PubNub streaming dataset** can also only be visualized by adding a tile to the dashboard, and configuring a PubNub data stream as the source.
 


### PR DESCRIPTION
Added instructions to clarify that if the customers have a locked firewall, they would need to allow outbound traffic to PubNub to be able to use the datasets.

Edit: (Adding some more context.)
I am on the PowerBI Team that owns Push Datasets. We discussed this internally and wanted to point out that if the customer locks down their environment to only a set of allowed outgoing traffic, then they should be aware that the web client calls into PubNub to get data and they need to add PubNub urls to their allowed list of outgoing traffic.