### PR TITLE
updating AnalyzeInExcel docs for audit event for report

### DIFF
--- a/powerbi-docs/service-admin-auditing.md
+++ b/powerbi-docs/service-admin-auditing.md
@@ -239,7 +239,7 @@ The following operations are available in both the audit and activity logs.
 | Added Power BI group members                      | AddGroupMembers                             |                                          |
 | Admin attached dataflow storage account to tenant | AdminAttachedDataflowStorageAccountToTenant | Not currently used                       |
 | Analyzed Power BI dataset                         | AnalyzedByExternalApplication               |                                          |
-| Analyzed Power BI report                          | AnalyzeInExcel                              | Downloading ODC file doesnt generate audit event                                         |
+| Analyzed Power BI report                          | AnalyzeInExcel                              | Downloading ODC file doesn't generate audit event                                         |
 | Attached dataflow storage account                 | AttachedDataflowStorageAccount              |                                          |
 | Binded Power BI dataset to gateway                | BindToGateway                               |                                          |
 | Canceled dataflow refresh                        | CancelDataflowRefresh                       |                                          |

--- a/powerbi-docs/service-admin-auditing.md
+++ b/powerbi-docs/service-admin-auditing.md
@@ -239,7 +239,7 @@ The following operations are available in both the audit and activity logs.
 | Added Power BI group members                      | AddGroupMembers                             |                                          |
 | Admin attached dataflow storage account to tenant | AdminAttachedDataflowStorageAccountToTenant | Not currently used                       |
 | Analyzed Power BI dataset                         | AnalyzedByExternalApplication               |                                          |
-| Analyzed Power BI report                          | AnalyzeInExcel                              |                                          |
+| Analyzed Power BI report                          | AnalyzeInExcel                              | Downloading ODC file doesnt generate audit event                                         |
 | Attached dataflow storage account                 | AttachedDataflowStorageAccount              |                                          |
 | Binded Power BI dataset to gateway                | BindToGateway                               |                                          |
 | Canceled dataflow refresh                        | CancelDataflowRefresh                       |                                          |

--- a/powerbi-docs/service-admin-auditing.md
+++ b/powerbi-docs/service-admin-auditing.md
@@ -239,7 +239,7 @@ The following operations are available in both the audit and activity logs.
 | Added Power BI group members                      | AddGroupMembers                             |                                          |
 | Admin attached dataflow storage account to tenant | AdminAttachedDataflowStorageAccountToTenant | Not currently used                       |
 | Analyzed Power BI dataset                         | AnalyzedByExternalApplication               |                                          |
-| Analyzed Power BI report                          | AnalyzeInExcel                              | Downloading ODC file doesn't generate audit event                                         |
+| Analyzed Power BI report                          | AnalyzeInExcel                              | Generated when users interact with the service. Downloading the `*.odc` file doesn't create an audit event                                         |
 | Attached dataflow storage account                 | AttachedDataflowStorageAccount              |                                          |
 | Binded Power BI dataset to gateway                | BindToGateway                               |                                          |
 | Canceled dataflow refresh                        | CancelDataflowRefresh                       |                                          |


### PR DESCRIPTION
audit event is generated only when user starts interacting with service. Menu for downloading "AnalyzeInExcel" from portal doesnt trigger audit event.