### PR TITLE
Update service-admin-auditing.md

### DIFF
--- a/powerbi-docs/service-admin-auditing.md
+++ b/powerbi-docs/service-admin-auditing.md
@@ -24,6 +24,7 @@ Knowing who is taking what action on which item in your Power BI tenant can be c
 | Global admins and auditors can search the unified audit log by using Office 365 Security & Compliance Center, the Microsoft 365 Security Center, and the Microsoft 365 Compliance Center. | There's no user interface to search the activity log yet. |
 | Global admins and auditors can download audit log entries by using Office 365 Management APIs and cmdlets. | Global admins and Power BI service admins can download activity log entries by using a Power BI REST API and management cmdlet. |
 | Keeps audit data for 90 days | Keeps activity data for 30 days (public preview) |
+| Retains audit data even if the tenant is moved to a different Azure region | Does not retain activity data when the tenant is moved to a different Azure region |
 | | |
 
 ## Use the activity log

--- a/powerbi-docs/service-admin-auditing.md
+++ b/powerbi-docs/service-admin-auditing.md
@@ -23,8 +23,8 @@ Knowing who is taking what action on which item in your Power BI tenant can be c
 | Only users with View-Only Audit Logs or Audit Logs permissions have access, such as global admins and auditors. | Global admins and Power BI service admins have access. |
 | Global admins and auditors can search the unified audit log by using Office 365 Security & Compliance Center, the Microsoft 365 Security Center, and the Microsoft 365 Compliance Center. | There's no user interface to search the activity log yet. |
 | Global admins and auditors can download audit log entries by using Office 365 Management APIs and cmdlets. | Global admins and Power BI service admins can download activity log entries by using a Power BI REST API and management cmdlet. |
-| Keeps audit data for 90 days | Keeps activity data for 30 days (public preview) |
-| Retains audit data even if the tenant is moved to a different Azure region | Does not retain activity data when the tenant is moved to a different Azure region |
+| Keeps audit data for 90 days. | Keeps activity data for 30 days (public preview). |
+| Retains audit data, even if the tenant is moved to a different Azure region. | Does not retain activity data when the tenant is moved to a different Azure region. |
 | | |
 
 ## Use the activity log


### PR DESCRIPTION
Added a comparison item to highlight that the activity log discards all existing data when the tenant is moved, while the audit log does not.