### PR TITLE
 updating the language fallback logic for subscription processing

### DIFF
--- a/powerbi-docs/consumer/end-user-subscribe.md
+++ b/powerbi-docs/consumer/end-user-subscribe.md
@@ -20,7 +20,7 @@ LocalizationGroup: Common tasks
 
 It's never been easier to stay up-to-date on your most important dashboards and reports. Subscribe to report pages and dashboards that matter most to you, and Power BI will email a snapshot to your inbox. You tell Power BI how often you want to receive the emails: daily, weekly, or when the data refresh. You can even set a specific time for Power BI to send the emails or have it run now.  In all, you can set up to 24 different subscriptions per report or dashboard.
 
-The email and snapshot will use the language set in Power BI settings (see [Supported languages and countries/regions for Power BI](../fundamentals/supported-languages-countries-regions.md)). If no language is defined, Power BI uses the language according to the locale setting in your current browser. To see or set your language preference, select the cog icon ![gear icon](./media/end-user-subscribe/power-bi-settings-icon.png) > **Settings > General > Language**. 
+The email and snapshot will use the language set in Power BI settings (see [Supported languages and countries/regions for Power BI](../fundamentals/supported-languages-countries-regions.md)). If no language is defined, Power BI uses english language as a fallback. To see or set your language preference, select the cog icon ![gear icon](./media/end-user-subscribe/power-bi-settings-icon.png) > **Settings > General > Language**. 
 
 ![Language dropdown](./media/end-user-subscribe/power-bi-language.png)
 


### PR DESCRIPTION
we recently made a change where we use the subscription owners locale to process subscriptions as long as the user has set the power bi language settings set correctly (**Settings > General > Language**). if the user hasnt defined this setting we fallback to English. 
updating the doc to reflect this change