### PR TITLE
fix typo in matrix selection example

### DIFF
--- a/powerbi-docs/developer/visuals/selection-api.md
+++ b/powerbi-docs/developer/visuals/selection-api.md
@@ -312,7 +312,7 @@ The visual code iterates the rows of the table and each row calls `withTable` ta
 public update(options: VisualUpdateOptions) {
     const host = this.host;
     const rowLevels: powerbi.DataViewHierarchyLevel[] = dataView.matrix.rows.levels;
-    const columnLevels: powerbi.DataViewHierarchyLevel[] = dataView.matrix.rows.levels;
+    const columnLevels: powerbi.DataViewHierarchyLevel[] = dataView.matrix.columns.levels;
 
     // iterate rows hierarchy
     nodeWalker(dataView.matrix.rows.root, rowLevels);


### PR DESCRIPTION
The current example does not work. Need to use dataView.matrix.**columns**.levels when creating the selection id for columns.