### PR TITLE
Update service-security-private-links.md for Publish to Web restrictions

### DIFF
--- a/powerbi-docs/admin/service-security-private-links.md
+++ b/powerbi-docs/admin/service-security-private-links.md
@@ -7,7 +7,7 @@ ms.reviewer: ''
 ms.service: powerbi
 ms.subservice: pbi-security
 ms.topic: how-to
-ms.date: 04/16/2021
+ms.date: 07/02/2021
 ms.custom: video--3yFtlZBpqs
 LocalizationGroup: Administration
 ---

--- a/powerbi-docs/admin/service-security-private-links.md
+++ b/powerbi-docs/admin/service-security-private-links.md
@@ -302,7 +302,7 @@ There are a few considerations to keep in mind while working with private endpoi
 * Any use of external images or themes are not available when using a private link environment.
 * If Internet access is disabled, and if the dataset or dataflow is connecting to a Power BI dataset or dataflow as a data source, the connection will fail.
 * Usage metrics do *not* work when private endpoints are enabled.
-* Publish to Web is not supported (and grayed out) when you enable **Block Public Internet Access** in Power BI.
+* Publish to Web is not supported when you enable **Azure Private Link** in Power BI.
 * Email subscriptions are not supported when you enable **Block Public Internet Access** in Power BI. 
 * [Microsoft Information Protection (MIP)](/microsoft-365/compliance/information-protection?view=o365-worldwide) does not currently support Private Links. This means that in [Power BI Desktop](service-security-sensitivity-label-overview.md#sensitivity-labels-in-power-bi-desktop-preview) running in an isolated network, the Sensitivity button will be grayed out, label information will not appear, and decryption of *.pbix* files will fail.
 


### PR DESCRIPTION
Currently Publish to Web is not supported when you enable Azure Private Link, so updating docs to make this clear. It is technically possible for Publish to Web to work with Azure Private Link enabled (as long as the tenant admin does not Block Public Internet Access), but that was hasn't been implemented so it would require a feature request to be prioritised before work will be funded to support Publish to Web with Azure Private Link.