### PR TITLE
Update service-connect-to-microsoft-sustainability-calculator.md

### DIFF
--- a/powerbi-docs/connect-data/service-connect-to-microsoft-sustainability-calculator.md
+++ b/powerbi-docs/connect-data/service-connect-to-microsoft-sustainability-calculator.md
@@ -30,6 +30,7 @@ To access the Microsoft Sustainability Calculator, you’ll need the following i
 
 - Billing account ID for Microsoft Customer Agreement (MCA)/Cloud Solution Provider (CSP) customers or enrollment ID for Enterprise Agreement (EA) customers
 - Billing ID for MCA/CSP customers or EA Admin read (minimum) access for EA customers
+- Azure subscription of type "Azure Plan"
 
 > [!NOTE]
 > Only Azure Administrator roles can authenticate and connect the Sustainability Calculator to company data. This note applies to the December 2020 preview release.


### PR DESCRIPTION
Legacy Azure CSP subscriptions of type "Azure Offer" don't work with Cost Management features and therefore Sustainability data. See email with Microsoft Azure Support.
--------------------------
From: Bethi Sunder Rao <V-BESUN@microsoftsupport.com> 
Sent: Friday, 30 July 2021 3:52 AM
To: Peter Foote <peter.foote@datacom.com.au>; Aman Lodhia <Aman.Lodhia@microsoft.com>; Norman Leung <Norman.Leung@datacom.com.au>
Cc: Raveendra Vempala <V-VERAVE@microsoftsupport.com>; Microsoft Support <support@microsoftsupport.com>; Tony Tang <tangtony@microsoft.com>; 
Subject: RE: Case 2107220060000384  Your question was s... - TrackingID#2107220060000384

Hello Peter Foote,

Hope you are doing well.
I got update from my technical advisory team and they confirmed that your subscription is under legacy CSP.
Azure Cost Management is natively available for direct partners who have on boarded their customers to a Microsoft Customer Agreement and have purchased an Azure Plan.
This article explains how partners use Azure Cost Management features and how they enable Cost Management access for their customers.
https://docs.microsoft.com/en-us/azure/cost-management-billing/costs/get-started-partners
--------------------------