### PR TITLE
Lifted a restriction

### DIFF
--- a/powerbi-docs/transform-model/dataflows/dataflows-azure-data-lake-storage-integration.md
+++ b/powerbi-docs/transform-model/dataflows/dataflows-azure-data-lake-storage-integration.md
@@ -30,8 +30,6 @@ There are two ways to configure which ADLS Gen 2 store to use: you can use a ten
 
 - TLS (Transport Layer Security) version 1.2 (or higher) is required to secure your endpoints. Web browsers and other client applications that use TLS versions earlier than TLS 1.2 won't be able to connect.
 
-- The ADLS Gen 2 account must be deployed in the [same region as your Power BI tenant](../admin/service-admin-where-is-my-tenant-located.md). An error occurs if the locations of the resources are not in the same region.
-
 - Finally, you can connect to any ADLS Gen 2 from the admin portal, but if you connect directly to a workspace, you must first ensure there are no dataflows in the workspace before connecting.
 
 The following table describes the permissions for ADLS and for Power BI required for ADLS Gen 2 and Power BI:


### PR DESCRIPTION
The restriction for "ADLS Gen 2 account must be deployed in the same region as your Power BI tenant. An error occurs if the locations of the resources are not in the same region" is updated. Customers can now use ADLS Gen2 account for different regions.