### PR TITLE
Aligning the gx64krb5 SSO Kerberos for SAP BW doc with the other docs

### DIFF
--- a/powerbi-docs/connect-data/service-gateway-sso-kerberos-sap-bw-gx64krb.md
+++ b/powerbi-docs/connect-data/service-gateway-sso-kerberos-sap-bw-gx64krb.md
@@ -16,7 +16,7 @@ LocalizationGroup: Gateways
 This article describes how to configure your SAP BW data source to enable SSO from the Power BI service by using gx64krb5.
 
 > [!IMPORTANT]
-> SAP no longer supports the gx64krb5, and as a result, Microsoft also has discontinued its support. Existing and new connections will continue to work properly until the end of 2020, but will not work beginning on January 1, 2021. Use CommonCryptoLib instead. 
+> While Microsoft allows you to create connections with gx64krb5, SAP no longer supports the gx64krb5 library, and as a result, Microsoft also has discontinued its support. Additionally, the steps required to configure it for the gateway are significantly more complex compared to CommonCryptoLib. For those reasons, Microsoft recommends to use CommonCryptoLib instead. 
 
 > [!NOTE]
 > You can complete the steps in this article in addition to the steps in [Configure Kerberos SSO](service-gateway-sso-kerberos.md) to enable SSO-based refresh for SAP BW Application Server-based reports in Power BI service. However, Microsoft recommends the use of CommonCryptoLib, not gx64krb5 as your SNC library. SAP no longer supports gx64krb5 and the steps required to configure it for the gateway are significantly more complex compared to CommonCryptoLib. For information about how to configure SSO by using CommonCryptoLib, see [Configure SAP BW for SSO using CommonCryptoLib](service-gateway-sso-kerberos-sap-bw-commoncryptolib.md). Use CommonCryptoLib *or* gx64krb5 as your SNC library, but not both. Do not complete the configuration steps for both libraries.

--- a/powerbi-docs/connect-data/service-gateway-sso-kerberos-sap-bw-gx64krb.md
+++ b/powerbi-docs/connect-data/service-gateway-sso-kerberos-sap-bw-gx64krb.md
@@ -16,7 +16,7 @@ LocalizationGroup: Gateways
 This article describes how to configure your SAP BW data source to enable SSO from the Power BI service by using gx64krb5.
 
 > [!IMPORTANT]
-> While Microsoft allows you to create connections with gx64krb5, SAP no longer supports the gx64krb5 library, and as a result, Microsoft also has discontinued its support. Additionally, the steps required to configure it for the gateway are significantly more complex compared to CommonCryptoLib. For those reasons, Microsoft recommends to use CommonCryptoLib instead. 
+> Although Microsoft allows you to create connections by using gx64krb5, SAP no longer supports the gx64krb5 library. As a result, Microsoft also has discontinued support for the gx64krb5 library. Also, the steps that are required to configure the library for the gateway are significantly more complex compared to CommonCryptoLib. For these reasons, we recommend that you use CommonCryptoLib instead of gx64krb5. 
 
 > [!NOTE]
 > You can complete the steps in this article in addition to the steps in [Configure Kerberos SSO](service-gateway-sso-kerberos.md) to enable SSO-based refresh for SAP BW Application Server-based reports in Power BI service. However, Microsoft recommends the use of CommonCryptoLib, not gx64krb5 as your SNC library. SAP no longer supports gx64krb5 and the steps required to configure it for the gateway are significantly more complex compared to CommonCryptoLib. For information about how to configure SSO by using CommonCryptoLib, see [Configure SAP BW for SSO using CommonCryptoLib](service-gateway-sso-kerberos-sap-bw-commoncryptolib.md). Use CommonCryptoLib *or* gx64krb5 as your SNC library, but not both. Do not complete the configuration steps for both libraries.

--- a/powerbi-docs/connect-data/service-gateway-sso-kerberos-sap-bw-gx64krb.md
+++ b/powerbi-docs/connect-data/service-gateway-sso-kerberos-sap-bw-gx64krb.md
@@ -7,7 +7,7 @@ ms.reviewer: ''
 ms.service: powerbi
 ms.subservice: powerbi-gateways
 ms.topic: how-to
-ms.date: 10/21/2020
+ms.date: 01/28/2022
 LocalizationGroup: Gateways
 ---
 


### PR DESCRIPTION
Other docs located here:
https://docs.microsoft.com/en-us/power-bi/connect-data/service-gateway-sso-kerberos#complete-data-source-specific-configuration-steps
https://docs.microsoft.com/en-us/power-bi/connect-data/service-gateway-sso-kerberos-sap-bw-gx64krb

Connections with gx64krb5 are still possible, but unsupported.