### PR TITLE
Refresh Id updated to Request Id

### DIFF
--- a/powerbi-docs/connect-data/asynchronous-refresh.md
+++ b/powerbi-docs/connect-data/asynchronous-refresh.md
@@ -166,9 +166,9 @@ The Power BI REST API supports limiting the requested number of entries in the r
 GET https://api.powerbi.com/v1.0/myorg/datasets/{datasetId}/refreshes?$top={$top}      
 ```
 
-## GET /refreshes/\<refreshId\>
+## GET /refreshes/\<requestId\>
 
-To check the status of a refresh operation, use the GET verb on the refresh object by specifying the **refreshId**. Here's an example of the response body. If the operation is in progress, `inProgress` is returned in status.
+To check the status of a refresh operation, use the GET verb on the refresh object by specifying the **requestId**. Here's an example of the response body. If the operation is in progress, `inProgress` is returned in status.
 
 ```json
 {
@@ -193,9 +193,9 @@ To check the status of a refresh operation, use the GET verb on the refresh obje
 
 ```
 
-## DELETE /refreshes/\<refreshId\>
+## DELETE /refreshes/\<requestId\>
 
-To cancel an in-progress refresh operation, use the DELETE verb on the refresh object by specifying the `refreshId`.
+To cancel an in-progress refresh operation, use the DELETE verb on the refresh object by specifying the `requestId`.
 
 For example,
 
@@ -207,9 +207,9 @@ DELETE https://api.powerbi.com/v1.0/myorg/groups/f089354e-8366-4e18-aea3-4cb4a3a
 
 #### Non-asynchronous refresh operations
 
-Scheduled and on-demand (manual) dataset refreshes cannot be cancelled by using `DELETE /refreshes/<refreshId>`.
+Scheduled and on-demand (manual) dataset refreshes cannot be cancelled by using `DELETE /refreshes/<requestId>`.
 
-Scheduled and on-demand (manual) dataset refreshes do not support getting refresh operation details by using `GET /refreshes/<refreshId>`.
+Scheduled and on-demand (manual) dataset refreshes do not support getting refresh operation details by using `GET /refreshes/<requestId>`.
 
 Get Details and Cancel are new operations for asynchronous refresh only. They are not supported for non-asynchronous refresh operations.
 


### PR DESCRIPTION
Hi team! 
The response from the GET refreshes does not include a refreshId. However it does include a requestId. When I tried to cancel the refresh operation, I used the requestId which was successful. Updated this page accordingly.


here's an example body which is returned from the GET call
{
      "requestId":"fed4279a-3cff-4923-b689-ea2697525313","id":79783403,"refreshType":"ReliableProcessing","startTime":"2022-0
3-03T16:34:34.133Z","status":"Unknown","extendedStatus":"InProgress"
    }

With the DELETE operation, I had to include the requestId and not the "id" as listed in the body.

After that, this was returned (as expected): 
 {
      "requestId":"fed4279a-3cff-4923-b689-ea2697525313","id":79783403,"refreshType":"ReliableProcessing","startTime":"2022-0
3-03T16:34:34.133Z","endTime":"2022-03-03T18:38:48.83Z","status":"Cancelled","extendedStatus":"Cancelled"
    }