### PR TITLE
Update service-gateway-sso-kerberos-sap-bw-commoncryptolib.md

### DIFF
--- a/powerbi-docs/connect-data/service-gateway-sso-kerberos-sap-bw-commoncryptolib.md
+++ b/powerbi-docs/connect-data/service-gateway-sso-kerberos-sap-bw-commoncryptolib.md
@@ -18,6 +18,10 @@ This article describes how to configure your SAP BW data source to enable SSO fr
 > [!NOTE]
 > Before you attempt to refresh a SAP BW-based report that uses Kerberos SSO, complete both the steps in this article and the steps in [Configure Kerberos SSO](service-gateway-sso-kerberos.md). Using CommonCryptoLib as your SNC library enables SSO connections to both SAP BW Application Servers and SAP BW Message Servers.
 
+> [!NOTE]
+> Configuring both libraries(sapcrypto and gx64krb5) on the same gateway server is an unsupported scenario. It’s not recommended to configure both libraries on the same gateway server as it’ll lead to a mix of libraries. If you want to use both libraries, please fully separate the gateway server. For example, configure gx64krb5 for server A then sapcrypto for server B. Please remember that any failure on server A which uses gx64krb5 is not supported as gx64krb5 is no longer supported by SAP and Microsoft.
+
+
 ## Configure SAP BW to enable SSO using CommonCryptoLib
 
 > [!NOTE]


### PR DESCRIPTION
Per discussion with the product group, configuring both libraries on the same gateway service is an unsupported scenario. It’s not recommended to configure both libraries on the same gateway server as it’ll lead to a mix of libraries. If users want to use both libraries, they should fully separate the gateway server. For example, configure gx64krb for server A then sapcrypto for server B. Any failure for gx64krb is not supported.
So I think it's better to clarify this on official doc. For more information, please refer to [this ICM](https://portal.microsofticm.com/imp/v3/incidents/details/297190892/home).