### PR TITLE
Adding link to devops stages

### DIFF
--- a/powerbi-docs/create-reports/deployment-pipelines-get-started.md
+++ b/powerbi-docs/create-reports/deployment-pipelines-get-started.md
@@ -16,7 +16,7 @@ ms.date: 02/14/2022
 
 This article walks you through the basic settings required for using deployment pipelines in Power BI service. It's recommended to read the [deployment pipelines introduction](deployment-pipelines-overview.md), before you proceed.
 
-In a deployment pipeline, one workspace is assigned to each [stage](../../azure/devops/pipelines/get-started/key-pipelines-concepts#stage). Before you start working with your pipeline in production, review the [capacity requirements](deployment-pipelines-troubleshooting.yml#what-type-of-capacity-can-i-assign-to-a-workspace-in-a-pipeline-) for the pipeline's workspaces.
+In a deployment pipeline, one workspace is assigned to each [stage](../../azure/devops/pipelines/get-started/key-pipelines-concepts.md#stage). Before you start working with your pipeline in production, review the [capacity requirements](deployment-pipelines-troubleshooting.yml#what-type-of-capacity-can-i-assign-to-a-workspace-in-a-pipeline-) for the pipeline's workspaces.
 
 ## Accessing deployment pipelines
 

--- a/powerbi-docs/create-reports/deployment-pipelines-get-started.md
+++ b/powerbi-docs/create-reports/deployment-pipelines-get-started.md
@@ -16,7 +16,7 @@ ms.date: 02/14/2022
 
 This article walks you through the basic settings required for using deployment pipelines in Power BI service. It's recommended to read the [deployment pipelines introduction](deployment-pipelines-overview.md), before you proceed.
 
-In a deployment pipeline, one workspace is assigned to each stage. Before you start working with your pipeline in production, review the [capacity requirements](deployment-pipelines-troubleshooting.yml#what-type-of-capacity-can-i-assign-to-a-workspace-in-a-pipeline-) for the pipeline's workspaces.
+In a deployment pipeline, one workspace is assigned to each [stage](../../azure/devops/pipelines/get-started/key-pipelines-concepts#stage). Before you start working with your pipeline in production, review the [capacity requirements](deployment-pipelines-troubleshooting.yml#what-type-of-capacity-can-i-assign-to-a-workspace-in-a-pipeline-) for the pipeline's workspaces.
 
 ## Accessing deployment pipelines
 


### PR DESCRIPTION
It may not be clear to a Power BI user what a stage is. I tried to add a link to this documentation, but I may not have gotten the syntax right.
https://docs.microsoft.com/en-us/azure/devops/pipelines/get-started/key-pipelines-concepts?view=azure-devops#stage

Alternatively a sentence or two of definition might be sufficient.