### PR TITLE
Update known-issue-dataflow-on-premium-gen2.md

### DIFF
--- a/powerbi-docs/troubleshoot/known-issues/known-issue-dataflow-on-premium-gen2.md
+++ b/powerbi-docs/troubleshoot/known-issues/known-issue-dataflow-on-premium-gen2.md
@@ -37,8 +37,6 @@ The Power BI team is working to continually improve dataflow reliability. As par
 
 It's also recommended to follow the suggestions within  [Best practices for designing and developing complex dataflows](/power-query/dataflows/best-practices-developing-complex-dataflows). You can also review refresh schedules and potentially move refresh times around to help avoid contention that leads to these issues.
 
-As a last resort, you can try swapping the workspace out of Premium to Pro and wait a few minutes. Then switch the workspace back to Premium. This solution may help to provide relief, but the issue could reoccur.
-
 ## Next steps
 
 - [About known issues](power-bi-known-issues.md)


### PR DESCRIPTION
Removed recommendation to switch from Premium to Pro and back as that no longer applies as a workaround based on recent product changes.