### PR TITLE
The admins can now enable or disable datamarts to security groups

### DIFF
--- a/powerbi-docs/transform-model/datamarts/datamarts-administration.md
+++ b/powerbi-docs/transform-model/datamarts/datamarts-administration.md
@@ -16,9 +16,9 @@ You can administer the use and settings for datamarts just like you can administ
 
 
 ## Enabling datamarts in the admin portal
-Power BI administrators can enable or disable datamart creation, using the setting found in the Power BI **admin portal**, as shown in the following image.
+Power BI administrators can enable or disable datamart creation for the enitre organization or for specific security groups, using the setting found in the Power BI **admin portal**, as shown in the following image.
 
-:::image type="content" source="media/datamarts-administration/datamarts-administration-01.png" alt-text="Screenshot of the admin portal to enable or disable datamarts.":::
+:::image type="content" source="![image](https://user-images.githubusercontent.com/58403397/190539634-a695ee83-e1a8-4988-989f-2baeec17e441.png)" alt-text="Screenshot of the admin portal to enable or disable datamarts.":::
 
 ### Keeping track of datamarts
 

--- a/powerbi-docs/transform-model/datamarts/datamarts-administration.md
+++ b/powerbi-docs/transform-model/datamarts/datamarts-administration.md
@@ -18,7 +18,7 @@ You can administer the use and settings for datamarts just like you can administ
 ## Enabling datamarts in the admin portal
 Power BI administrators can enable or disable datamart creation for the enitre organization or for specific security groups, using the setting found in the Power BI **admin portal**, as shown in the following image.
 
-:::image type="content" source="![image](https://user-images.githubusercontent.com/58403397/190539634-a695ee83-e1a8-4988-989f-2baeec17e441.png)" alt-text="Screenshot of the admin portal to enable or disable datamarts.":::
+:::image type="content" source="media/datamarts-administration/datamarts-administration-06.png" alt-text="Screenshot of the admin portal to enable or disable datamarts.":::
 
 ### Keeping track of datamarts
 


### PR DESCRIPTION
The PBI admins can now enable or disable datamarts capability to the entire organisation or to specific security groups. The current image on Microsoft Docs is outdated. I couldn't upload the new image to the media folder, so I uploaded the file directly here.