### PR TITLE
Remove ADAL mention and replace with MSAL

### DIFF
--- a/powerbi-docs/developer/embedded/embedded-faq.yml
+++ b/powerbi-docs/developer/embedded/embedded-faq.yml
@@ -217,7 +217,7 @@ sections:
           
           You can use your existing directory if you already have an Azure AD tenant. You can also create a new Azure AD tenant for your embedded application content security.
           
-          To get an Azure AD token, you can use one of the [Azure Active Directory Authentication Libraries](/azure/active-directory/develop/active-directory-authentication-libraries). There are client libraries available for multiple platforms.
+          To get an Azure AD token, you can use one of the [Microsoft Authentication Libraries](/azure/active-directory/develop/msal-overview). There are client libraries available for multiple platforms.
           
       - question: |
           What object ID is the service principal object ID?


### PR DESCRIPTION
ADAL is being deprecated and support ends in Dec 31 , 2022. Hence, we need to be pointing readers to MSAL and not ADAL