### PR TITLE
Updated Considerations and Limitation section

### DIFF
--- a/powerbi-docs/collaborate-share/service-embed-secure.md
+++ b/powerbi-docs/collaborate-share/service-embed-secure.md
@@ -132,6 +132,8 @@ You can add as many buttons as you'd like to create a low-code custom experience
 
 * The automatic authentication capabilities provided with the **Embed** option don't work with the Power BI JavaScript API. They are blocked in PBI embedded client SDK starting with the version 2.10.4. For the Power BI JavaScript API, use the [user-owns-data](../developer/embedded/embed-sample-for-your-organization.md) embedding method.
 
+* The automatic authentication capabilities don't work when embedded in applications, including in mobile and desktop applications
+
 * The authentication token lifetime is controlled based on your Azure AD settings. When the authentication token expires, the user will need to sign in again to get an updated authentication token. The default lifetime is one hour, but it might be shorter or longer in your organization. You can't automatically refresh the token in this scenario.
 
 ## Next steps

--- a/powerbi-docs/collaborate-share/service-embed-secure.md
+++ b/powerbi-docs/collaborate-share/service-embed-secure.md
@@ -7,7 +7,7 @@ ms.reviewer: lukaszp
 ms.service: powerbi
 ms.subservice: pbi-collaborate-share
 ms.topic: how-to
-ms.date: 10/18/2022
+ms.date: 02/03/2023
 LocalizationGroup: Share your work
 ---
 
@@ -132,7 +132,7 @@ You can add as many buttons as you'd like to create a low-code custom experience
 
 * The automatic authentication capabilities provided with the **Embed** option don't work with the Power BI JavaScript API. They are blocked in PBI embedded client SDK starting with the version 2.10.4. For the Power BI JavaScript API, use the [user-owns-data](../developer/embedded/embed-sample-for-your-organization.md) embedding method.
 
-* The automatic authentication capabilities don't work when embedded in applications, including in mobile and desktop applications
+* The automatic authentication capabilities don't work when they're embedded in applications, including in mobile and desktop applications.
 
 * The authentication token lifetime is controlled based on your Azure AD settings. When the authentication token expires, the user will need to sign in again to get an updated authentication token. The default lifetime is one hour, but it might be shorter or longer in your organization. You can't automatically refresh the token in this scenario.
 


### PR DESCRIPTION
Added a new limitation for native applications like mobile or desktop apps.  Secure Embed cannot work with if the embed code is used inside a mobile/desktop app because it is dependent on browser’s cookies for authentication and browser’ local storage for refreshing the iframe after authentication.