### PR TITLE
URL filters in SharePoint

### DIFF
--- a/powerbi-docs/collaborate-share/service-url-filters.md
+++ b/powerbi-docs/collaborate-share/service-url-filters.md
@@ -239,7 +239,7 @@ URL filters are supported in some embedding scenarios and not in others.
 - [Embedding a report in a secure portal or website](service-embed-secure.md) is supported.
 - URL filters are supported in Power BI Embedded. See [Power BI Embedded advanced URL filtering capabilities](https://azure.microsoft.com/updates/power-bi-embedded-advanced-url-filtering-capabilities) for details.
 - Query string filtering doesn't work with [Publish to web](service-publish-to-web.md) or [Export to PDF](end-user-pdf.md).
-- [Embed with report web part in SharePoint Online](service-embed-report-spo.md) doesn't support URL filters.
+- [Embed with report web part in SharePoint Online](service-embed-report-spo.md) doesn't support URL filters. Use the <iframe> embed option in SharePoint if you need to filter by URL.
 - Teams doesn't allow specifying a URL.
 
 ## Next steps


### PR DESCRIPTION
Clarify that we can filter reports via the URL in SharePoint by using the <iframe> embed option.