### PR TITLE
Update service-create-distribute-apps.md

### DIFF
--- a/powerbi-docs/collaborate-share/service-create-distribute-apps.md
+++ b/powerbi-docs/collaborate-share/service-create-distribute-apps.md
@@ -107,7 +107,7 @@ On the **Audience** tab, you create and manage audience groups within the app.
      
 1. For each audience group, grant access to either all people in your organization or specific users or groups. You can also expand the **Advanced** option to configure the following settings per audience group: 
 
-    **Allow users to share the datasets in this app**: This option gives app consumers permission to share the app and underlying datasets of the app audience.
+    **Allow users to share the datasets in this app**: This option gives app consumers permission to share the underlying datasets of the app audience.
     
     **Allow users to build content with the datasets in this app**: This option lets your app consumers create their own reports and dashboards based on the app audience datasets.
     


### PR DESCRIPTION
I have tested this. The end-user gets reshare permission is on the dataset, not on the app. In fact, I didn't find any way that an end-user can share the app other than if they are members of Member/Admin role (or Contributor role if admin allows that)