### PR TITLE
Update power-bi-data-points.md

### DIFF
--- a/powerbi-docs/visuals/power-bi-data-points.md
+++ b/powerbi-docs/visuals/power-bi-data-points.md
@@ -113,9 +113,8 @@ Depending on the configuration, a map can have the following:
 
 ### Maps: Azure Maps
 
-- Max points: 30,000
-
-For more information, see [High density line sampling](../create-reports/desktop-high-density-sampling.md).
+- Latitude, longitude: 30,000 For more information, see [High density line sampling](../create-reports/desktop-high-density-sampling.md).
+- Location: 3,500
 
 ### Matrix
 - Rows: Virtualization by using Window of 500 rows at a time.


### PR DESCRIPTION
Updated the limits on the Azure Maps visual. Azure Maps added geocoding support a while back and only supports up to 3500 locations. If lat/long are used, then 30K rows are supported (same as previous doc version)