### PR TITLE
Bypass the limitation of the 28 days by using Linguistic Schema.

### DIFF
--- a/powerbi-docs/natural-language/q-and-a-limitations.md
+++ b/powerbi-docs/natural-language/q-and-a-limitations.md
@@ -47,7 +47,7 @@ The new tooling dialog allows users to customize and improve the natural languag
 
 ## Review question limitations
 
-The review questions only store questions asked against your data model for up to 28 days. When using the new review questions capability, you may notice some questions aren't recorded. They aren't recorded by design, as the natural language engine performs a series of data cleansing steps to ensure every key stroke from a user isn't recorded or shown.
+The review questions only store questions asked against your data model for up to 28 days. When using the new review questions capability, you may notice some questions aren't recorded. They aren't recorded by design, as the natural language engine performs a series of data cleansing steps to ensure every key stroke from a user isn't recorded or shown. This limitation could be bypassed by saving (exporting) the Linguistic Schema and by importing it again after those 28 days. 
 
 Power BI administrators can use the tenant settings to manage the ability to store questions. Permissions are based on security groups. 
 


### PR DESCRIPTION
I believe is important to note that we can use the Linguistic Schema export/import feature to bypass the 28 days limitation from the Q&A engine