### PR TITLE
Update datamarts-access-control.md

### DIFF
--- a/powerbi-docs/transform-model/datamarts/datamarts-access-control.md
+++ b/powerbi-docs/transform-model/datamarts/datamarts-access-control.md
@@ -7,7 +7,7 @@ ms.reviewer: ''
 ms.service: powerbi
 ms.subservice: pbi-dataflows
 ms.topic: how-to
-ms.date: 06/16/2022
+ms.date: 07/12/2023
 LocalizationGroup: Data from files
 ---
 
@@ -90,7 +90,7 @@ A datamart can get marked as an unavailable datamart when one of the following s
 
 :::image type="content" source="media/datamarts-access-control/datamarts-access-control-01.png" alt-text="Screenshot of the request access setting.":::
 
-Situation 3: When a Premium workspace is migrated to another Premium Capacity in a different region, the datamart would become unavailable with the error "Unable to open the datamart because the workspace region has changed. To open the datamart, reconnect the workspace to the region connected when the datamart was created." This is by design as the region where the Datamarts were created should be the region where the workspace resides, as migrations are not supported
+**Situation 3:** When a Premium workspace is migrated to another Premium Capacity in a different region, the datamart will become unavailable with the error "Unable to open the datamart because the workspace region has changed. To open the datamart, reconnect the workspace to the region connected when the datamart was created." This behavior is by design, since the region where the datamarts were created must be the region where the workspace resides, and migrations are not supported.
 
 ## Next steps
 This article provided information about controlling access to datamarts. 

--- a/powerbi-docs/transform-model/datamarts/datamarts-access-control.md
+++ b/powerbi-docs/transform-model/datamarts/datamarts-access-control.md
@@ -90,7 +90,7 @@ A datamart can get marked as an unavailable datamart when one of the following s
 
 :::image type="content" source="media/datamarts-access-control/datamarts-access-control-01.png" alt-text="Screenshot of the request access setting.":::
 
-**Situation 3:** When a Premium workspace is migrated to another Premium Capacity in a different region, the datamart will become unavailable with the error "Unable to open the datamart because the workspace region has changed. To open the datamart, reconnect the workspace to the region connected when the datamart was created." This behavior is by design, since the region where the datamarts were created must be the region where the workspace resides, and migrations are not supported.
+**Situation 3:** When a Premium workspace is migrated to another Premium capacity in a different region, the datamart will become unavailable with the error: "Unable to open the datamart because the workspace region has changed. To open the datamart, reconnect the workspace to the region connected when the datamart was created." This behavior is by design since the region where the datamarts were created must be the region where the workspace resides, and migrations are not supported.
 
 ## Next steps
 This article provided information about controlling access to datamarts. 

--- a/powerbi-docs/transform-model/datamarts/datamarts-access-control.md
+++ b/powerbi-docs/transform-model/datamarts/datamarts-access-control.md
@@ -90,6 +90,7 @@ A datamart can get marked as an unavailable datamart when one of the following s
 
 :::image type="content" source="media/datamarts-access-control/datamarts-access-control-01.png" alt-text="Screenshot of the request access setting.":::
 
+Situation 3: When a Premium workspace is migrated to another Premium Capacity in a different region, the datamart would become unavailable with the error "Unable to open the datamart because the workspace region has changed. To open the datamart, reconnect the workspace to the region connected when the datamart was created." This is by design as the region where the Datamarts were created should be the region where the workspace resides, as migrations are not supported
 
 ## Next steps
 This article provided information about controlling access to datamarts. 


### PR DESCRIPTION
By design limitation confirmed by PG when customer attempts to migrate workspace from Premium capacity in one region to another region. Datamarts by design don't support migation to another region's workspace.