### PR TITLE
Update export-paginated-report.md

### DIFF
--- a/powerbi-docs/developer/embedded/export-paginated-report.md
+++ b/powerbi-docs/developer/embedded/export-paginated-report.md
@@ -168,7 +168,7 @@ Here's an example for supplying an effective identity (user name) with an access
 
 ## Concurrent requests
 
-The `exportToFile` API supports concurrent export job requests. The maximum number of concurrent report pages depends on the type and number of SKUs you have. The maximum number of [concurrent paginated report render requests](../../paginated-reports/paginated-capacity-planning.md#concurrent-requests), is 500. To avoid exceeding the limit and getting a *Too Many Requests (429)* error, either distribute the load over time, or get a larger capacity.
+The `exportToFile` API supports concurrent export job requests. The maximum number of concurrent report pages depends on the type and number of SKUs you have. The maximum number of [concurrent paginated report render requests](../../paginated-reports/paginated-capacity-planning.md#concurrent-requests), is 500. To avoid exceeding the limit and getting a *Too Many Requests (429)* error, either distribute the load over time or across capacities.
 
 when using [Premium Per User (PPU)](../../enterprise/service-premium-per-user-faq.yml), the `exportToFile` API allows just *one* request in a five-minute window. Multiple requests within a five-minute window will result in a *Too Many Requests* (429) error.
 


### PR DESCRIPTION
Fixing one of the lines to be accurate with what is supported in the product. The system concurrency limits are flat irrespective of SKU for paginated reports.