### PR TITLE
Update service-premium-per-user-faq.yml

### DIFF
--- a/powerbi-docs/enterprise/service-premium-per-user-faq.yml
+++ b/powerbi-docs/enterprise/service-premium-per-user-faq.yml
@@ -126,6 +126,7 @@ sections:
           * You can't have a dataflow run in a PPU workspace, import it to a Power BI dataset in another workspace, and then allow users without a PPU license to access the content.
           
           * Any workspace migrated from a PPU environment to a non-PPU environment (such as Premium or shared environments) must have its datasets refreshed before use. Reports opened after such migrations without being refreshed will fail with an error like: *This operation isn't allowed, as the database 'database name' is in a blocked state.* You might need to do a full refresh through SSMS to fix this.
+          * PPU license is a limited license, one of the limitations is you cant share data between tenants.So a dataset from a different tenant (which also uses PPU) cant pull data from a dataflow in a different tenant also using PPU)
 
 additionalContent: |
  

--- a/powerbi-docs/enterprise/service-premium-per-user-faq.yml
+++ b/powerbi-docs/enterprise/service-premium-per-user-faq.yml
@@ -126,7 +126,8 @@ sections:
           * You can't have a dataflow run in a PPU workspace, import it to a Power BI dataset in another workspace, and then allow users without a PPU license to access the content.
           
           * Any workspace migrated from a PPU environment to a non-PPU environment (such as Premium or shared environments) must have its datasets refreshed before use. Reports opened after such migrations without being refreshed will fail with an error like: *This operation isn't allowed, as the database 'database name' is in a blocked state.* You might need to do a full refresh through SSMS to fix this.
-          * PPU license is a limited license, one of the limitations is you cant share data between tenants.So a dataset from a different tenant (which also uses PPU) cant pull data from a dataflow in a different tenant also using PPU)
+          
+          * When using PPU you can't share data between tenants. For example, if you have a dataflow on a PPU capacity, you can't pull its data from a different tenant.
 
 additionalContent: |
  


### PR DESCRIPTION
PPU license is a limited license, one of the limitations is you cant share data between tenants.

So a dataset from a different tenant (which also uses PPU) can't pull data from a dataflow in a different tenant also using PPU)