### PR TITLE
Fixed REST URL

### DIFF
--- a/powerbi-docs/connect-data/asynchronous-refresh.md
+++ b/powerbi-docs/connect-data/asynchronous-refresh.md
@@ -181,7 +181,7 @@ The response body might look like the following example:
 The Power BI REST API supports limiting the requested number of entries in the refresh history by using the optional `$top` parameter. If not specified, the default is all available entries.
 
 ```http
-GET https://api.powerbi.com/v1.0/myorg/datasets/{datasetId}/refreshes?$top={$top}      
+GET https://api.powerbi.com/v1.0/myorg/groups/{groupId}/datasets/{datasetId}/refreshes?$top={$top}      
 ```
 
 ## GET /refreshes/\<requestId>


### PR DESCRIPTION
The REST URL must include a workspace (aka group) id to connect to a dataset. The REST URL was incomplete and thus didn't work.