### PR TITLE
Remove limitation that no longer applies

### DIFF
--- a/powerbi-docs/enterprise/directlake-overview.md
+++ b/powerbi-docs/enterprise/directlake-overview.md
@@ -110,8 +110,6 @@ The following are known issues and limitations during **preview**:
 
 - Direct Lake tables cannot currently be mixed with other table types, such as Import, DirectQuery, or Dual, in the same dataset. Composite models are not yet supported.
 
-- Direct Lake datasets do not currently support calculation groups.
-
 - Direct Lake datasets do not currently support Publish to Web because SSO requires authenticated users.
 
 - Calculated columns and calculated tables are not yet supported.


### PR DESCRIPTION
Since September 6th, calc groups are supported for directlake. See this post: https://powerbi.microsoft.com/en-us/blog/announcing-calculation-groups-for-direct-lake-datasets/#:~:text=And%20calculation%20groups%20are%20a,any%20measure%20in%20your%20model.