### PR TITLE
Update desktop-composite-models.md

### DIFF
--- a/powerbi-docs/transform-model/desktop-composite-models.md
+++ b/powerbi-docs/transform-model/desktop-composite-models.md
@@ -467,7 +467,7 @@ The following Live Connect tabular sources can't be used with composite models:
 
 Using streaming semantic models in composite models isn't supported.
 
-The existing limitations of DirectQuery still apply when you use composite models. Many of these limitations are now per table, depending upon the storage mode of the table. For example, a calculated column on an import table can refer to other tables, but a calculated column on a DirectQuery table can still refer only to columns on the same table. Other limitations apply to the model as a whole, if any of the tables within the model are DirectQuery. For example, the QuickInsights feature isn't available on a model if any of the tables within it has a storage mode of DirectQuery.
+The existing limitations of DirectQuery still apply when you use composite models. Many of these limitations are now per table, depending upon the storage mode of the table. For example, a calculated column on an import table can refer to other tables that are not in DirectQuery, but a calculated column on a DirectQuery table can still refer only to columns on the same table. Other limitations apply to the model as a whole, if any of the tables within the model are DirectQuery. For example, the QuickInsights feature isn't available on a model if any of the tables within it has a storage mode of DirectQuery.
 
 
 


### PR DESCRIPTION
This is the error message when user creates a calculated column in an import table that uses a column from a DirectQuery table: «Refresh is not supported for datasets with a calculated table or calculated column that depends on a table which references Analysis Services using DirectQuery.»