### PR TITLE
Update rest-api.md to have new url

### DIFF
--- a/powerbi-docs/report-server/rest-api.md
+++ b/powerbi-docs/report-server/rest-api.md
@@ -7,7 +7,7 @@ ms.reviewer: ''
 ms.service: powerbi
 ms.subservice: powerbi-report-server
 ms.topic: conceptual
-ms.date: 05/25/2018
+ms.date: 02/06/2024
 ---
 
 # Develop with the REST APIs for Power BI Report Server
@@ -43,7 +43,7 @@ A REST API request/response pair can be separated into five components:
 
 ## API documentation
 
-A modern REST API calls for modern API documentation. The REST API is built on the OpenAPI specification (a.k.a. the swagger specification) and documentation is available on [Microsoft Learn](https://learn.microsoft.com/rest/api/power-bi-report/).
+A modern REST API calls for modern API documentation. The REST API is built on the OpenAPI specification (a.k.a. the swagger specification) and documentation is available on [Microsoft Learn](/rest/api/power-bi-report/).
 
 ## Testing API calls
 
@@ -51,7 +51,7 @@ A tool for testing HTTP request/response messages is [Fiddler](https://www.teler
 
 ## Related content
 
-Review the available APIs over on [Microsoft Learn](https://learn.microsoft.com/rest/api/power-bi-report/).
+Review the available APIs over on [Microsoft Learn](/rest/api/power-bi-report/).
 
 Samples are available on [GitHub](https://github.com/Microsoft/Reporting-Services). The sample includes an HTML5 app built on TypeScript, React, and webpack along with a PowerShell example.
 

--- a/powerbi-docs/report-server/rest-api.md
+++ b/powerbi-docs/report-server/rest-api.md
@@ -43,7 +43,7 @@ A REST API request/response pair can be separated into five components:
 
 ## API documentation
 
-A modern REST API calls for modern API documentation. The REST API is built on the OpenAPI specification (a.k.a. the swagger specification) and documentation is available on [SwaggerHub](https://app.swaggerhub.com/apis/microsoft-rs/PBIRS/2.0). Beyond documenting the API, SwaggerHub helps generate a client library in the language of choice – JavaScript, TypeScript, C#, Java, Python, Ruby, and more.
+A modern REST API calls for modern API documentation. The REST API is built on the OpenAPI specification (a.k.a. the swagger specification) and documentation is available on [Microsoft Learn](https://learn.microsoft.com/rest/api/power-bi-report/).
 
 ## Testing API calls
 

--- a/powerbi-docs/report-server/rest-api.md
+++ b/powerbi-docs/report-server/rest-api.md
@@ -51,7 +51,7 @@ A tool for testing HTTP request/response messages is [Fiddler](https://www.teler
 
 ## Related content
 
-Review the available APIs over on [SwaggerHub](https://app.swaggerhub.com/apis/microsoft-rs/PBIRS/2.0).
+Review the available APIs over on [Microsoft Learn](https://learn.microsoft.com/rest/api/power-bi-report/).
 
 Samples are available on [GitHub](https://github.com/Microsoft/Reporting-Services). The sample includes an HTML5 app built on TypeScript, React, and webpack along with a PowerShell example.
 


### PR DESCRIPTION
We created a new set of swagger documenation pages on Microsoft Learn for the PBIRS api, this updated the link to point to it.