### PR TITLE
Fix dataset stringification in RLS effective identity to produce a valid request

### DIFF
--- a/powerbi-docs/developer/embedded/cloud-rls.md
+++ b/powerbi-docs/developer/embedded/cloud-rls.md
@@ -93,7 +93,7 @@ public EmbedToken GetEmbedToken(Guid reportId, IList<Guid> datasetIds, [Optional
         var rlsIdentity = new EffectiveIdentity(
             username: "France",
             roles: new List<string>{ "CountryDynamic" },
-            datasets: new List<string>{ datasetId.ToString()}
+            datasets: datasetIds.Select(id => id.ToString()).ToList());
         );
        
         // Create a request for getting an embed token for the rls identity defined above


### PR DESCRIPTION
Calling `.ToString()` on the list of `datasetId`s will not return the expected individual GUIDs of the datasets. Instead, it returns a string representation of the list type.

This results in an invalid request, leading to a failure with a status code of 400 when attempting to generate an embed token using `pbiClient.EmbedToken.GenerateToken(tokenRequest)` a few lines later.