### PR TITLE
Update support-timeline.md

### DIFF
--- a/powerbi-docs/report-server/support-timeline.md
+++ b/powerbi-docs/report-server/support-timeline.md
@@ -25,10 +25,11 @@ This support policy allows us to deliver innovation to customers at a rapid rate
 
 | **Version** | **Availability date** | **Support end date** |
 | --- | --- | --- |
-| September 2023 | September 2023 | September 2024|
-| May 2023 | May 2023 | May 2024|
-| January 2023 | January 2023 | January 2024|
-| September 2022 | September 2022 | September 2022 and all previous versions no longer supported|
+| January 2024 | January 2024 | May 2025 |
+| September 2023 | September 2023 | January 2025|
+| May 2023 | May 2023 | September 2024|
+| January 2023 | January 2023 | May 2024 and all previous versions no longer supported|
+
 
 To download Power BI Report Server, and Power BI Desktop for Power BI Report Server, go to [On-premises reporting with Power BI Report Server](https://powerbi.microsoft.com/report-server/).
 

--- a/powerbi-docs/report-server/support-timeline.md
+++ b/powerbi-docs/report-server/support-timeline.md
@@ -7,7 +7,7 @@ ms.reviewer: ''
 ms.service: powerbi
 ms.subservice: powerbi-report-server
 ms.topic: conceptual
-ms.date: 11/28/2023
+ms.date: 05/24/24
 ---
 
 # Support timeline for Power BI Report Server

--- a/powerbi-docs/report-server/support-timeline.md
+++ b/powerbi-docs/report-server/support-timeline.md
@@ -7,7 +7,7 @@ ms.reviewer: ''
 ms.service: powerbi
 ms.subservice: powerbi-report-server
 ms.topic: conceptual
-ms.date: 05/24/24
+ms.date: 05/24/2024
 ---
 
 # Support timeline for Power BI Report Server


### PR DESCRIPTION
Added January 2024
I think  the support end date showed is worng because after the next release, the previous release continues to receive security updates for the remainder of the 12-month release lifespan.

So for example the version September 2023 wil receive security updates form January 2024 + 12 month (January 2025).

This is what I understand reading the explanation of life cycle, And if I am right the image is wrong too.