### PR TITLE
Fixed broken image links

### DIFF
--- a/powerbi-docs/includes/rls-desktop-define-roles.md
+++ b/powerbi-docs/includes/rls-desktop-define-roles.md
@@ -11,15 +11,15 @@ To define security roles:
 
 1. From the **Modeling** tab, select **Manage Roles**.
 
-   ![Screenshot of the Modeling tab, highlighting Manage roles.](../includes/media/rls-desktop-define-roles/powerbi-desktop-security.png)
+   ![Screenshot of the Modeling tab, highlighting Manage roles.](https://github.com/MicrosoftDocs/powerbi-docs/blob/main/powerbi-docs/includes/media/rls-desktop-define-roles/powerbi-desktop-security.png)
 
 1. From the **Manage roles** window, select **New** to create a new role.
 
-   ![Screenshot of the Manage roles window, highlighting create new role button.](../includes/media/rls-desktop-define-roles/powerbi-security-newrole.png)
+   ![Screenshot of the Manage roles window, highlighting create new role button.](https://github.com/MicrosoftDocs/powerbi-docs/blob/main/powerbi-docs/includes/media/rls-desktop-define-roles/powerbi-security-newrole.png)
 
 1. Under **Roles**, provide a name for the role and select enter.
 
-    ![Screenshot of the Manage roles window, highlighting renaming a role.](../includes/media/rls-desktop-define-roles/powerbi-security-renamerole.png)
+    ![Screenshot of the Manage roles window, highlighting renaming a role.](https://github.com/MicrosoftDocs/powerbi-docs/blob/main/powerbi-docs/includes/media/rls-desktop-define-roles/powerbi-security-renamerole.png)
 
    > [!NOTE]
    > You can't define a role with a comma, for example `London,ParisRole`.
@@ -28,21 +28,21 @@ To define security roles:
 
 1. Under **Filter data**, use the default editor to define your roles. The expressions created return a true or false value.
 
-    ![Screenshot of the Manage roles window default editor for defining row level security.](../includes/media/rls-desktop-define-roles/powerbi-security-defaulteditor.png)
+    ![Screenshot of the Manage roles window default editor for defining row level security.](https://github.com/MicrosoftDocs/powerbi-docs/blob/main/powerbi-docs/includes/media/rls-desktop-define-roles/powerbi-security-defaulteditor.png)
 
    > [!NOTE]
    > Not all row-level security filters supported in Power BI can be defined using the default editor. Limitations include expressions that today can only be defined using DAX including dynamic rules such as *username()* or *userprincipalname()*. To define roles using these filters switch to use the DAX editor.
 
 1. Optionally select **Switch to DAX editor** to switch to using the DAX editor to define your role. DAX expressions return a value of true or false. For example: ```[Entity ID] = “Value”```. The DAX editor is complete with autocomplete for formulas (intellisense). You can select the checkmark above the expression box to validate the expression and the X button above the expression box to revert changes.
 
-   ![Screenshot of the Manage roles window, highlighting an example DAX expression.](../includes/media/rls-desktop-define-roles/powerbi-security-daxeditor.png)
+   ![Screenshot of the Manage roles window, highlighting an example DAX expression.](https://github.com/MicrosoftDocs/powerbi-docs/blob/main/powerbi-docs/includes/media/rls-desktop-define-roles/powerbi-security-daxeditor.png)
 
    > [!NOTE]
    > You can use *username()* within this expression. Be aware that *username()* has the format of *DOMAIN\username* within Power BI Desktop. Within the Power BI service and Power BI Report Server, it's in the format of the user's User Principal Name (UPN). Alternatively, you can use *userprincipalname()*, which always returns the user in the format of their user principal name, *username\@contoso.com*. Additionally, in this expression box, use commas to separate DAX function arguments even if you're using a locale that normally uses semicolon separators (e.g. French or German).
 
 1. You can switch back to the default editor by selecting **Switch to default editor**. All changes made in either editor interface persist when switching interfaces when possible. When defining a role using the DAX editor that can't be defined in the default editor, if you attempt to switch to the default editor you'll be prompted with a warning that switching editors may result in some information being lost. To keep this information, select **Cancel** and continue only editing this role in the DAX editor.
 
-   ![Screenshot of the dialog confirming you would like to switch to the default editor.](../includes/media/rls-desktop-define-roles/powerbi-security-switchtodefaulteditor.png)
+   ![Screenshot of the dialog confirming you would like to switch to the default editor.](https://github.com/MicrosoftDocs/powerbi-docs/blob/main/powerbi-docs/includes/media/rls-desktop-define-roles/powerbi-security-switchtodefaulteditor.png)
 
    > [!NOTE]
    > In this expression box, use commas to separate DAX function arguments even if you're using a locale that normally uses semicolon separators (e.g. French or German).


### PR DESCRIPTION
@emlisa I think your change has broken the image links in the docs, the main RLS page is in the fabric-docs repo, and that references this page in the powerbi-docs repo. The page loads but all the images are broken and I think its because the links above are relative to this repo, but once embedded in fabric-docs these files dont exist. Not sure what the standards are to cross repo references so I have added absolute links for now