### PR TITLE
Update service-encryption-byok.md

### DIFF
--- a/powerbi-docs/enterprise/service-encryption-byok.md
+++ b/powerbi-docs/enterprise/service-encryption-byok.md
@@ -14,7 +14,7 @@ LocalizationGroup: Premium
 
 # Bring your own encryption keys for Power BI
 
-Power BI encrypts data *at-rest* and *in process*. By default, Power BI uses Microsoft-managed keys to encrypt your data. In Power BI Premium, you can also use your own keys for data at-rest that's imported into a semantic model. This approach is often described as *bring your own key* (BYOK). For more information, see [Data source and storage considerations](#data-source-and-storage-considerations). 
+By default, Power BI uses Microsoft-managed keys to encrypt your data. In Power BI Premium, you can also use your own keys for data at-rest that's imported into a semantic model. This approach is often described as *bring your own key* (BYOK). For more information, see [Data source and storage considerations](#data-source-and-storage-considerations). 
 
 ## Why use BYOK?
 


### PR DESCRIPTION
Proposal to remove the first line: Power BI encrypts both data-at rest and data-in process. This is not completely true as Power BI BYOK only encrypts data-at-rest while data-in-process is encrypted by Microsoft managed keys. This sentence is causing confusion to customers and customers tend to assume that Power BI BYOK only encrypts "data at rest"