### PR TITLE
Update desktop-access-database-errors.md

### DIFF
--- a/powerbi-docs/connect-data/desktop-access-database-errors.md
+++ b/powerbi-docs/connect-data/desktop-access-database-errors.md
@@ -64,6 +64,7 @@ To change the bit version of Microsoft Office to match the bit version of your P
 
 If the error occurs with an Excel 97-2003 XLS workbook, you can avoid using the Access Database Engine by opening the XLS file in Excel and saving it as an XLSX file.
 
+<a name="situation-3-trouble-using-access-or-xls-files-with-a-microsoft-365-subscription"></a>
 ## You use Access or XLS files with Microsoft 365
 
 Subscription versions of Office 2013-2019 that use Click-to-Run installation technology register the Access Database Engine provider in a virtual registry location that only Microsoft Office processes can access. The Mashup Engine, which is responsible for running non-Microsoft 365 Excel and Power BI Desktop, isn't an Office process, so it can't use the Access Database Engine provider.

--- a/powerbi-docs/connect-data/desktop-access-database-errors.md
+++ b/powerbi-docs/connect-data/desktop-access-database-errors.md
@@ -22,12 +22,9 @@ In Power BI Desktop, imported Access databases and Excel 97-2003 XLS files both 
 <a name="situation-1-no-access-database-engine-is-installed"></a>
 ## No Access Database Engine installed
 
-If a Power BI Desktop error message indicates the Access Database Engine isn't installed, [install the Access Database Engine](https://www.microsoft.com/download/details.aspx?id=54920) from the downloads page. Install the version, either 32-bit or 64-bit, that matches your Power BI Desktop version.
+If a Power BI Desktop error message indicates the Access Database Engine isn't installed, [install the Access 365 Runtime](https://support.microsoft.com/office/download-and-install-microsoft-365-access-runtime-185c5a32-8ba9-491e-ac76-91cbe3ea09c9). Install the version, either 32-bit or 64-bit, that matches your Power BI Desktop version.
 
 If you work with dataflows and use a gateway to connect to the data, you must install the Access Database Engine on the computer that runs the gateway.
-
->[!NOTE]
->If the Access Database Engine bit version you install is different from your Microsoft Office bit version, your Office applications won't be able to use the Access Database Engine.
 
 <a name="situation-2-the-access-database-engine-bit-version-32-bit-or-64-bit-is-different-from-your-power-bi-desktop-bit-version"></a>
 ## Access Database Engine bit version is different from Power BI Desktop bit version
@@ -67,28 +64,11 @@ To change the bit version of Microsoft Office to match the bit version of your P
 
 If the error occurs with an Excel 97-2003 XLS workbook, you can avoid using the Access Database Engine by opening the XLS file in Excel and saving it as an XLSX file.
 
-### Solution 4: Install both versions of the Access Database Engine
-
-You can install both versions of the Access Database Engine to resolve the issue for Power Query for Excel and Power BI Desktop. This workaround isn't recommended, because it can introduce errors and issues for applications that use the Access Database Engine bit version you installed first.
-
-To use both Access Database Engine bit versions:
-
-1. [Install both bit versions of the Access Database Engine](https://www.microsoft.com/download/details.aspx?id=54920) from the download page.
-
-1. Run each version of the Access Database Engine by using the `/passive` switch. For example:
-
-   ```console
-   c:\users\joe\downloads\AccessDatabaseEngine.exe /passive
-
-   c:\users\joe\downloads\AccessDatabaseEngine_x64.exe /passive
-   ```
-
-<a name="situation-3-trouble-using-access-or-xls-files-with-a-microsoft-365-subscription"></a>
 ## You use Access or XLS files with Microsoft 365
 
-Office 2013 and Office 2016 Microsoft 365 subscriptions register the Access Database Engine provider in a virtual registry location that only Microsoft Office processes can access. The Mashup Engine, which is responsible for running non-Microsoft 365 Excel and Power BI Desktop, isn't an Office process, so it can't use the Access Database Engine provider.
+Subscription versions of Office 2013-2019 that use Click-to-Run installation technology register the Access Database Engine provider in a virtual registry location that only Microsoft Office processes can access. The Mashup Engine, which is responsible for running non-Microsoft 365 Excel and Power BI Desktop, isn't an Office process, so it can't use the Access Database Engine provider.
 
-To fix this situation, [download and install the Access Database Engine Redistributable](https://www.microsoft.com/download/details.aspx?id=54920) that matches the bit version of your Power BI Desktop installation, 32-bit or 64-bit.
+To fix this situation, see [Unable to use the Access ODBC, OLEDB, or DAO interfaces outside Office Click-to-Run applications](https://learn.microsoft.com/office/troubleshoot/access/cannot-use-odbc-or-oledb) for installation guidance.
 
 ## Other import issues
 


### PR DESCRIPTION
Updating out of date and inaccurate information regarding supported use of the Access Database Engine. The Access 365 Runtime is the only redistributable installation that's currently within mainstream support. Additionally, Access 365 is the only version of Access that has changes included to work with the PowerBI Gateway service account. Lastly, we don't support installing multiple instances of the Access Database Engines using different bitnesses. Office only supports one bitness across all Office products on the machine. There should only be one installation on the machine. Either that's an Office suite or the standalone Access 365 Runtime. The only remaining exception to that is Office 2019, this either requires Access 2013 Runtime or switching to a newer Office install. Pointed to know issues article for this tope. Please reach out if there are any questions.