### PR TITLE
Update service-datasets-build-permissions.md

### DIFF
--- a/powerbi-docs/connect-data/service-datasets-build-permissions.md
+++ b/powerbi-docs/connect-data/service-datasets-build-permissions.md
@@ -62,7 +62,7 @@ If you distribute an app from a workspace, removing people's access to the app d
 
 ## Configure how users request Build permission
 
-Certain actions, such as creating a report based on a semantic model or accessing the details page of a semantic model in the data hub, require Build permission on the semantic model. By default, when users who don't have Build permission try these actions, they get a dialog box that lets them send email to the semantic model owner requesting Build permission. The email includes the user's details, the name of the semantic model they’re requesting access to, and any other information they optionally provide.
+Certain actions, such as creating a report based on a semantic model, require Build permission on the semantic model. By default, when users who don't have Build permission try these actions, they get a dialog box that lets them send email to the semantic model owner requesting Build permission. The email includes the user's details, the name of the semantic model they’re requesting access to, and any other information they optionally provide.
 
 ![Screenshot of the default Build permission request dialog.](media/service-datasets-build-permissions/build-permission-default-request-dialog.png)
  


### PR DESCRIPTION
Users that don't have Build permissions can still view the item details page in OneLake Catalog, so this part of the sentence could be removed.