### PR TITLE
🐲 Updating content lifecycle management series with new guidance for Copilot and re-using semantic models

### DIFF
--- a/powerbi-docs/guidance/powerbi-implementation-planning-content-lifecycle-management-plan-design.md
+++ b/powerbi-docs/guidance/powerbi-implementation-planning-content-lifecycle-management-plan-design.md
@@ -136,8 +136,8 @@ There are several different ways in which users can engage with semantic models 
 
 These various scenarios create a number of considerations that you must keep in mind for your semantic models, such as:
 - Which permissions you'll grant to users, and how you'll manage these permissions. We recommend that users complete a training before getting [build permissions](../connect-data/service-datasets-build-permissions.md).
-- Whether you'll add [perspectives](/analysis-services/tabular-models/perspectives-ssas-tabular?view=asallproducts-allversions) to your model, or not. You can only add perspectives by using the [TMDL view in Power BI Desktop](../transform-model/desktop-tmdl-view.md), or by using other, third-party tools. We recommend that you add perspectives when users will use personalize visuals or composite models.
-- Which fields you should hide in your model, and whether you need to enable the _[IsPrivate](/dotnet/api/microsoft.analysisservices.tabular.table.isprivate?view=analysisservices-dotnet)_ TOM property of tables to avoid that they or their child objects appear as suggestions. Note that the _Private_ TOM property can only be set by using external tools on a model metadata file (like .bim or .tmdl) or a remote model that is published in the Power BI service.
+- Whether you'll add [perspectives](/analysis-services/tabular-models/perspectives-ssas-tabular?view=asallproducts-allversions&preserve-view=true) to your model, or not. You can only add perspectives by using the [TMDL view in Power BI Desktop](../transform-model/desktop-tmdl-view.md), or by using other, third-party tools. We recommend that you add perspectives when users will use personalize visuals or composite models.
+- Which fields you should hide in your model, and whether you need to enable the _[IsPrivate](/dotnet/api/microsoft.analysisservices.tabular.table.isprivate?view=analysisservices-dotnet&preserve-view=true)_ TOM property of tables to avoid that they or their child objects appear as suggestions. Note that the _Private_ TOM property can only be set by using external tools on a model metadata file (like .bim or .tmdl) or a remote model that is published in the Power BI service.
 - How you'll document your model, and what that documentation should entail. We recommend that you make documentation tailored to specific use-cases and that you include relevant and useful information, and not exports of model metadata like DAX measure expressions, which are generally not useful for end-users.
 - How you'll advise users to choose one approach over another.
 
@@ -150,8 +150,8 @@ If users have build permissions to a model, then they can also [connect to a sem
 
 When users will use analyze in Excel to query your semantic model, you might need to consider things like the following: 
 - Certain features like [field parameters](../create-reports/power-bi-field-parameters.md) or [measure dynamic format strings](../create-reports/desktop-dynamic-format-strings.md) only work in Power BI, and not in Excel. To achieve a similar result, you need to use other approaches.
-- Analyze in Excel requires that the column property _[IsAvailableinMDX](/dotnet/api/microsoft.analysisservices.tabular.column.isavailableinmdx.md?view=analysisservices-dotnet)_ is enabled. If users won't use Excel, then disabling this property might result in smaller and more performant models.
-- Users can't view [hidden columns or measures](/analysis-services/tabular-models/hide-or-freeze-columns-ssas-tabular.md?view=asallproducts-allversions) in the semantic model, like they can from Power BI Desktop (by right-clicking the data pane, and selecting "view hidden").
+- Analyze in Excel requires that the column property _[IsAvailableinMDX](/dotnet/api/microsoft.analysisservices.tabular.column.isavailableinmdx.md?view=analysisservices-dotnet&preserve-view=true)_ is enabled. If users won't use Excel, then disabling this property might result in smaller and more performant models.
+- Users can't view [hidden columns or measures](/analysis-services/tabular-models/hide-or-freeze-columns-ssas-tabular.md?view=asallproducts-allversions&preserve-view=true) in the semantic model, like they can from Power BI Desktop (by right-clicking the data pane, and selecting "view hidden").
 - Users can't create their own measures or [visual calculations](../transform-model/desktop-visual-calculations-overview.md) in Excel, like they can when using a live connection from Power BI Desktop. However, they can reference the pivot table fields in other Excel cells and worksheets for custom calculations.
 - Users of analyze in Excel often require additional training about how to use it. This is particularly true if they expect an export-like experience or they express an intent to save offline copies of the data. Consider training users about things such as:
   - How to refresh the data.
@@ -179,7 +179,7 @@ You also need to spend additional effort training users:
 
 > [! TIP]
 > See the following articles for additional, detailed tips and considerations about optimizing models to work well with Copilot:
-> - [Optimization for report authors and model consumers](../guidance/power-bi-optimization#optimizing-for-report-authors-and-model-consumers.md)
+> - [Optimization for report authors and model consumers](../guidance/power-bi-optimization.md#optimizing-for-report-authors-and-model-consumers)
 > - [Update your data model to work well with Copilot for Power BI](../create-reports/copilot-evaluate-data.md)
 > - [Write DAX queries with Copilot](/dax/dax-copilot.md)
 

--- a/powerbi-docs/guidance/powerbi-implementation-planning-content-lifecycle-management-plan-design.md
+++ b/powerbi-docs/guidance/powerbi-implementation-planning-content-lifecycle-management-plan-design.md
@@ -8,7 +8,7 @@ ms.service: powerbi
 ms.subservice: powerbi-resource
 ms.topic: conceptual
 ms.custom: fabric-cat
-ms.date: 12/30/2024
+ms.date: 03/13/2025
 ---
 
 # Power BI implementation planning: Plan and design content
@@ -96,6 +96,131 @@ Answer questions like the following to help you determine whether the content is
 
 When you've sufficiently identified and described the content you'll create, you should next decide how content creators should collaborate.
 
+## Determine how users will consume the content
+
+In Power BI, there are many different ways in which users can consume content, including semantic models and reports. Depending on how people will access and use this content, you will need to make different decisions about its design and how you will develop it. Some of these decisions can drastically alter both how you make the content, and how much time and effort it takes. Typically, the more different ways that people will use your models and reports, the more considerations you keep in mind, and the higher the resulting development cost. 
+
+### Use and re-use of semantic models
+
+Semantic models are debatably the most important item types in Power BI and Fabric, since users can consume them by using many different downstream approaches and items. If you will only distribute reports, then you will make very different design decisions as when users will connect various items to the model to do their own analyses or accomplish their own goals.
+
+You can re-use a shared semantic model by using the following downstream item types:
+
+- Power BI 
+  - [Reports](../connect-data/desktop-report-lifecycle-datasets.md)
+  - [Paginated reports](../paginated-reports/report-builder-shared-datasets.md)
+  - [Scorecards](../create-reports/service-goals-create.md)
+  - [Excel (analyze in Excel pivot tables)](../collaborate-share/service-analyze-in-excel.md)
+  - [Semantic models (composite models)](../transform-model/desktop-composite-models.md)
+
+- Microsoft Fabric
+  - [Activator (formerly Reflex)](/fabric/real-time-intelligence/data-activator/activator-introduction)
+  - [AI skills](/fabric/data-science/concept-ai-skill)
+  - [Copilot](../create-reports/copilot-ask-data-question.md)
+  - [Explorations](../consumer/explore-data-service.md)
+  - [Metric sets](../create-reports/create-metric-sets.md)
+  - [Notebooks](/fabric/data-science/read-write-power-bi-python) (via the [Semantic Link](/fabric/data-science/semantic-link-power-bi?tabs=sql) and [semantic-link-labs](https://github.com/microsoft/semantic-link-labs) libraries)
+
+The following sections give an overview of important considerations when you use semantic models with some of these items.
+
+> [! NOTE]
+> Many of these options are only available if you enable the relevant tenant settings. Ensure that you familiarize yourself with the tenant settings to know what consumption methods are possible in the workspace where you'll publish your semantic model. If these options are limited to specific security groups, then ensure you identify whether your users belong (or should belong) to these security groups, or not.
+
+#### Reports
+
+There are several different ways in which users can engage with semantic models via reports:
+- **Viewing reports.** The standard scenario, in which a user views data in a report that you distribute or share with them.
+- **Connecting to the semantic model and creating a new report.** With [build permissions](../connect-data/service-datasets-build-permissions.md), users can create a new report in Power BI Desktop or in the Power BI service. This report has a live connection to the shared semantic model. Users can also convert the live connected report to a new composite semantic model that queries the original by using DirectQuery.
+- **Creating an exploration from an existing report visual.** With build permissions, users can also select a [supported visual](../consumer/explore-data-service.md#supported-visuals) to create an exploration of its data. This creates a new exploration item which allows the user to add fields or change formatting. Users can save and share the resulting exploration if they meet the [required criteria for licensing, workspace membership, and item permissions](../consumer/explore-data-service.md#considerations-and-limitations).
+- **Personalizing report visuals, in which users can change field and formatting.** [Personalize visuals](../create-reports/power-bi-personalize-visuals.md?tabs=powerbi-desktop) works similar to an exploration, but it only requires read permissions, and doesn't create a new item. Personalize visuals also use any perspectives that a user applies to a report page, which limits the available fields that a user can see and use.
+
+These various scenarios create a number of considerations that you must keep in mind for your semantic models, such as:
+- Which permissions you'll grant to users, and how you'll manage these permissions. We recommend that users complete a training before getting [build permissions](../connect-data/service-datasets-build-permissions.md).
+- Whether you'll add [perspectives](/analysis-services/tabular-models/perspectives-ssas-tabular?view=asallproducts-allversions) to your model, or not. You can only add perspectives by using the [TMDL view in Power BI Desktop](../transform-model/desktop-tmdl-view.md), or by using other, third-party tools. We recommend that you add perspectives when users will use personalize visuals or composite models.
+- Which fields you should hide in your model, and whether you need to enable the _[IsPrivate](/dotnet/api/microsoft.analysisservices.tabular.table.isprivate?view=analysisservices-dotnet)_ TOM property of tables to avoid that they or their child objects appear as suggestions. Note that the _Private_ TOM property can only be set by using external tools on a model metadata file (like .bim or .tmdl) or a remote model that is published in the Power BI service.
+- How you'll document your model, and what that documentation should entail. We recommend that you make documentation tailored to specific use-cases and that you include relevant and useful information, and not exports of model metadata like DAX measure expressions, which are generally not useful for end-users.
+- How you'll advise users to choose one approach over another.
+
+> [! CAUTION]
+> Once you grant read or build permissions to a semantic model, then users might be able to query any table or column in your model by using the approaches described in this section. This is true even if you don't expose that table, measure, or column in a report. Ensure that you always protect sensitive data by using data security, or exclude it from your model. That way, you can avoid unintentionally exposing sensitive information to the wrong people.
+
+#### Excel (analyze in Excel pivot tables)
+
+If users have build permissions to a model, then they can also [connect to a semantic model from Excel](../collaborate-share/service-analyze-in-excel.md) and query it by using MDX from an Excel pivot table. This can be useful when users prefer to work in Excel to explore or analyze data, themselves.
+
+When users will use analyze in Excel to query your semantic model, you might need to consider things like the following: 
+- Certain features like [field parameters](../create-reports/power-bi-field-parameters.md) or [measure dynamic format strings](../create-reports/desktop-dynamic-format-strings.md) only work in Power BI, and not in Excel. To achieve a similar result, you need to use other approaches.
+- Analyze in Excel requires that the column property _[IsAvailableinMDX](/dotnet/api/microsoft.analysisservices.tabular.column.isavailableinmdx.md?view=analysisservices-dotnet)_ is enabled. If users won't use Excel, then disabling this property might result in smaller and more performant models.
+- Users can't view [hidden columns or measures](/analysis-services/tabular-models/hide-or-freeze-columns-ssas-tabular.md?view=asallproducts-allversions) in the semantic model, like they can from Power BI Desktop (by right-clicking the data pane, and selecting "view hidden").
+- Users can't create their own measures or [visual calculations](../transform-model/desktop-visual-calculations-overview.md) in Excel, like they can when using a live connection from Power BI Desktop. However, they can reference the pivot table fields in other Excel cells and worksheets for custom calculations.
+- Users of analyze in Excel often require additional training about how to use it. This is particularly true if they expect an export-like experience or they express an intent to save offline copies of the data. Consider training users about things such as:
+  - How to refresh the data.
+  - Filter the data _before_ adding fields to the pivot table.
+  - Avoiding large and detailed queries without filters.
+  - Power BI Desktop will be more performant than Analyze in Excel, because analyze in Excel queries the model by using MDX, but Power BI Desktop queries the model with DAX.
+  - How to avoid creating governance or security risks while still leveraging Excel the way they prefer.
+
+#### Copilot and AI skills
+
+If users have read permissions to a model, then can use natural language to explore and ask questions about their data by using [Copilot](../create-reports/copilot-ask-data-question.md). Alternatively, they can also ask data questions about their data in an [AI skill](/fabric/data-science/concept-ai-skill.md), but unlike Copilot, you must first create and share this item with them.
+
+When users want to interact with your semantic model by using natural language, there are considerable consequences for the design and implementation of your model:
+- **Linguistic schema:** You'll have to add synonyms and relationships to your model so that the appropriate English words and terms are associated with the correct model objects.
+- **Naming conventions:** You'll have to use AI-friendly, English naming conventions. This means that you should avoid duplicate or overly-similar field names, acronyms, symbols, and abbreviations, even if they are standard in your organization.
+- **Properties:** You'll have to set properties like column or measure descriptions, data categories, and others so that AI tools can better recognize and use these fields.
+- **Hiding fields:** You'll have to hide fields that you don't want to expose to Copilot or use in its responses.
+
+You also need to spend additional effort training users:
+- What Copilot or AI skills can and can't do.
+- When to use Copilot or AI skills to explore data over another (non-AI) approach.
+- How to write effective prompts.
+- How to validate outputs.
+- How to troubleshoot unexpected outputs. 
+
+> [! TIP]
+> See the following articles for additional, detailed tips and considerations about optimizing models to work well with Copilot:
+> - [Optimization for report authors and model consumers](../guidance/power-bi-optimization#optimizing-for-report-authors-and-model-consumers.md)
+> - [Update your data model to work well with Copilot for Power BI](../create-reports/copilot-evaluate-data.md)
+> - [Write DAX queries with Copilot](/dax/dax-copilot.md)
+
+Copilot and other generative AI technology have important limitations and considerations that you should also understand in the planning and design stage of your content:
+- It is non-deterministic, which means that the same input on the same context might produce a different output.
+- You can get low-quality or inaccurate outputs, such as when the tool hallucinates, or overstates the importance of certain facts. Copilot might also be incorrect or inaccurate by omission, where it leaves out essential information.
+- The tools are limited by their training data, so questions about more novel information are less likely to produce useful outputs.
+
+> [! CAUTION]
+> You should mitigate the risks of these limitations and considerations. Copilot, AI skills, LLMs, and generative AI are nascent technology, so you should not use them for autonomous, high-risk, or business-critical processes and decision-making.
+> For more information, see also [Security guidance for Large Language Models](/ai/playbook/technology-guidance/generative-ai/mlops-in-openai/security/security-recommend.md).
+
+#### Paginated reports
+
+You can write a DAX query for a semantic model to create a paginated report with the query result. This is relevant if users require paginated reports and you intend to use your semantic model as the data source.
+
+When you plan to create paginated reports on a semantic model, you might need to consider the following points:
+- How you will write and maintain the DAX queries, such as by using the DAX query view of Power BI Desktop, or other third-party tools.
+- Whether you need to make design decisions to ensure your semantic model is performant when queried, such as materializing certain data in a model column or table.
+- Whether you will embed paginated reports into your interactive Power BI reports or not by using the [paginated report visual](../visuals/paginated-report-visual.md).
+- How you will ensure that there is not redundancy between your paginated reports and other reports.
+- In which format you should distribute the paginated reports, and whether you require sensitivity labels or data loss prevention to protect those outputs from becoming a governance or security risk.
+
+#### Others
+
+There are also other ways to consume semantic models. Some examples are below:
+
+- **Activator (formerly Reflex):** You can use a semantic model to automate data alerts and trigger downstream flows, such as those you create by using Power Automate.
+- **Metric sets:** You can create a metric set, which includes measures and recommended dimensions from multiple semantic models in one place. Metric sets can improve data discovery for users.
+- **Explorations:** Aside from creating explorations from reports and Copilot outputs, users can also create explorations from a semantic model. 
+
+### Distribution and sharing of Reports
+
+Depending on how you will [distribute and share](../guidance/powerbi-implementation-planning-content-distribution-sharing.md) your Power BI reports, you will make different design choices. For instance, cross-report drillthrough is a feature that lets users navigate between reports in the same workspace or app. However, you can't use cross-report drillthrough if you embed a report or share it publicly via Publish-to-Web.
+
+### Other items
+
+Depending on how people will use your content and the underlying data, you might need to turn to other item types in Power BI or Fabric. For instance, if users want to add their own data and calculations, they could use composite models with your semantic model. Alternatively, you might make other centralized data items for them to consume in new models, such as a dataflow. 
+
+Once you determine how users will consume the content you make, you should next decide how content creators should collaborate during development.
+
 ## Decide how content creators should collaborate
 
 As a solution increases in scope and complexity, it might become necessary for multiple content creators and owners to work in collaboration. When creating complex solutions, we recommend that you use effective tools that help structure, manage, and support collaboration. There are many ways to collaborate when producing Power BI content, such as by using Microsoft Teams, Azure DevOps, or GitHub.
@@ -132,9 +257,9 @@ We recommend that you define a structured process for how content creators shoul
 - How file sync conflicts are resolved.
 - When to archive and remove files from a document library that are no longer relevant.
 
-### Azure DevOps
+### Azure DevOps or GitHub Enterprise
 
-Content creators and owners can also communicate and collaborate in a central, organized hub by using [Azure DevOps](/azure/devops/user-guide/what-is-azure-devops?view=azure-devops&preserve-view=true).
+Content creators and owners can also communicate and collaborate in a central, organized hub by using [Azure DevOps](/azure/devops/user-guide/what-is-azure-devops?view=azure-devops&preserve-view=true) or GitHub Enterprise.
 
 :::image type="content" source="media/powerbi-implementation-planning-content-lifecycle-management-plan-design/collaborate-azure-devops.svg" alt-text="Diagram shows approach 2, which is about collaborating by using Azure DevOps. Items shown in the diagram are described next." border="false":::
 
@@ -147,7 +272,7 @@ Content creators and owners can also communicate and collaborate in a central, o
 > - **[Azure Boards](/azure/devops/boards/get-started/what-is-azure-boards?view=azure-devops&preserve-view=true)**: Allows you to use boards to track tasks and plans as work items, and link or refer to work items from other Azure DevOps services.
 > - **[Azure Wiki](/azure/devops/project/wiki/wiki-create-repo?view=azure-devops&tabs=browser&preserve-view=true)**: Allows you to share information with their team to understand and contribute to content.
 
-By using Azure DevOps, content creators use projects to structure their communication, planning, and work. Additionally, content creators can orchestrate content lifecycle management from within Azure DevOps by performing _source control_, validation, and deployment. Source control is the process of managing more granular changes to content code and metadata.
+By using Azure DevOps or GitHub Enterprise, content creators use projects to structure their communication, planning, and work. Additionally, content creators can orchestrate content lifecycle management from within Azure DevOps by performing _source control_, validation, and deployment. Source control is the process of managing more granular changes to content code and metadata.
 
 Azure DevOps is often a good choice for more advanced collaboration scenarios, because there are supporting services and options to orchestrate content creation and deployment.
 
@@ -292,6 +417,7 @@ Content creators can author content directly in the Fabric portal. In this scena
 > - **Identify whether multiple content creators need to collaborate**: Ensure that collaborating content creators are using file types that support version control, like .pbip files.
 > - **Decide how content creators will collaborate**: Decide how sophisticated the collaboration will be. Additionally, decide how you'll facilitate this collaboration, such as by using Microsoft Teams, Azure DevOps, or GitHub.
 > - **Decide the format of content**: Decide whether Power BI semantic models and reports will consist of .pbix or .pbip files (or other formats like .bim or .tmdl for models), and whether reports will use the PBIR format or not.
+> - **Determine how content will be consumed**: Evaluate how users will engage with data. Decide which item types you need to create to support consumption, and whether users require read permissions only, or also build permissions to underlying semantic models or other data items. If users do require build permissions, determine early-on how they will consume semantic models, and how you will train them to do this, effectively.
 > - **Set up collaboration tools**: Ensure that you perform the necessary first-time setup for the solution or project. Make key decisions about how you'll manage collaboration by using these tools.
 > - **Store data source files in SharePoint or OneLake**: Store small, simple data source files in SharePoint. Otherwise, use OneLake or ADLSGen2 (if they're available) instead.
 > - **Store content and supporting files in SharePoint, Microsoft Teams, or a Git repository**: For simpler, smaller projects, use SharePoint for most files if it's organized and you practice good access management. For larger environments or when parallel collaboration is required, consider using a Git repository in GitHub or Azure DevOps, which will provide detailed visibility of content changes.

--- a/powerbi-docs/guidance/powerbi-implementation-planning-content-lifecycle-management-support-monitor.md
+++ b/powerbi-docs/guidance/powerbi-implementation-planning-content-lifecycle-management-support-monitor.md
@@ -8,7 +8,7 @@ ms.service: powerbi
 ms.subservice: powerbi-resource
 ms.topic: conceptual
 ms.custom: fabric-cat
-ms.date: 03/13/2024
+ms.date: 03/13/2025
 ---
 
 # Power BI implementation planning: Support and monitor content

--- a/powerbi-docs/guidance/powerbi-implementation-planning-content-lifecycle-management-support-monitor.md
+++ b/powerbi-docs/guidance/powerbi-implementation-planning-content-lifecycle-management-support-monitor.md
@@ -8,7 +8,7 @@ ms.service: powerbi
 ms.subservice: powerbi-resource
 ms.topic: conceptual
 ms.custom: fabric-cat
-ms.date: 12/30/2024
+ms.date: 03/13/2024
 ---
 
 # Power BI implementation planning: Support and monitor content
@@ -81,6 +81,7 @@ Consider the following points when supporting consumers who only need to view co
   - Resolving data discrepancies.
 - **How to use the solution**: What sort of assistance is available to help consumers use and fully understand the solution? An overview page within the report or a short video tutorial can be helpful for users (for example, it could show how to [drillthrough](../create-reports/desktop-drillthrough.md) to another report). Providing that type of help can lead to increased adoption of the solution, greater return on investment, and fewer support cases.
 - **How to accept feedback**: When the consumer has a new request or enhancement, how should they submit their request? A feedback loop (such as a form) allows you to accept ideas for improving the solution. Feedback loops are often considered alongside support planning because it's a closely related concept.
+- **How to use data**: How can users leverage tools and features like personalize visuals, Copilot, or explorations to explore data from read-only experiences? When should they request build permissions if they need to make their own content, and how should they make this request? What training is available to support people in these features, or to transition from read-only consumers to individuals who might build and share their own content?
 
 > [!NOTE]
 > Expect that once a solution is deployed to production, you'll receive different types and volumes of feedback compared to that which you received during validation. Anticipate that there will be higher volumes of requests and feedback during this _hypercare_ period (the period immediately after a major change). Plan accordingly for this higher volume, and try to see it as an opportunity to build trust with the user community.
@@ -103,6 +104,8 @@ Consider the following points when supporting both [data creators](powerbi-imple
 - **How to update data connectivity**: If an author needs access to a gateway or a connection, what's the procedure they should follow to request updates (if they don't have [permissions](/data-integration/gateway/manage-security-roles))? Common situations include:
   - [Adding a new data source connection](../connect-data/service-gateway-data-sources.md)
   - [Adding a new user for a data source connection](/data-integration/gateway/manage-security-roles#connection-roles)
+- **How to use AI and improve productivity**: What should an author do to ensure that they remain effective and efficient? How should they best use Copilot and other assistive AI tools to augment their work without creating risk or wasting time?
+  - [Updating a data model to work well with Copilot](../create-reports/copilot-evaluate-data.md)
 
 > [!TIP]
 > Be prepared to address the most urgent support issues quickly to allow users to continue being productive. When they're blocked, a user might find a workaround (which might not be ideal) to keep moving, especially when there's a slow response from their support channel.

--- a/powerbi-docs/guidance/powerbi-implementation-planning-content-lifecycle-management-validate.md
+++ b/powerbi-docs/guidance/powerbi-implementation-planning-content-lifecycle-management-validate.md
@@ -8,7 +8,7 @@ ms.service: powerbi
 ms.subservice: powerbi-resource
 ms.topic: conceptual
 ms.custom: fabric-cat
-ms.date: 12/30/2024
+ms.date: 03/13/2025
 ---
 
 # Power BI implementation planning: Validate content

--- a/powerbi-docs/guidance/powerbi-implementation-planning-content-lifecycle-management-validate.md
+++ b/powerbi-docs/guidance/powerbi-implementation-planning-content-lifecycle-management-validate.md
@@ -168,6 +168,15 @@ There are different ways that you can conduct a peer review.
 
 Once you complete a peer review cycle, you should document and incorporate any recommended changes. If necessary, you should resubmit the changes for approval before moving on to user testing. Typically, multiple iterations of peer review are only needed when there are many changes or a few complex changes to test.
 
+### Manually test Copilot and AI skills outputs
+
+You can use Copilot or AI skills to allow users to ask questions about your data model by using natural language. However, using these tools leverage generative AI, and might return low-quality or inaccurate outputs. It is always important to evaluate these outputs before you use them. 
+
+To test Copilot and AI skills outputs, you can:
+- Ask simple questions testing known benchmarks, such as the total sales in a previous month, or the total number of customers or products.
+- Compare outputs to results obtained from reports or _ad hoc_ analyses.
+- Compare outputs before and after [making changes to a semantic model](../create-reports/copilot-evaluate-data.md).
+
 ### Automate testing
 
 Content creators can automate testing so that tests are performed automatically prior to deployment. Automated tests typically involve preprepared test conditions that are run and orchestrated programmatically in response to certain actions, like saving content or submitting a pull request (PR). The results of automated tests are automatically stored for later reference and documentation.


### PR DESCRIPTION
- Added section in _Plan and design content_ about planning how consumers will use content, including the re-use of semantic models.
- Added updates in _Validate content_ about testing Copilot and AI skill outputs.
- Added updates in _Support and monitor content_ about supporting consumers who want to use data and creators who want to improve productivity or use AI.
- Misc updates for content freshness.