### PR TITLE
Update the list of required properties in the definition.pbir file

### DIFF
--- a/powerbi-docs/developer/projects/projects-report.md
+++ b/powerbi-docs/developer/projects/projects-report.md
@@ -101,6 +101,8 @@ Using a `byConnection` reference, the following properties must be specified:
 |pbiModelDatabaseName     |   The remote semantic model ID.      |
 |connectionType     |   Type of connection. For service remote semantic model, this value should be `pbiServiceXmlaStyleLive`.      |
 |pbiModelVirtualServerName    |  An internal property that should have the value, `sobe_wowvirtualserver`.       |
+|pbiServiceModelId    |  An internal property that should have the value, `null`.       |
+|name    |  An internal property that should have the value, `EntityDataSource`.       |
 
 Example using `byConnection`:
 


### PR DESCRIPTION
A few additional properties (`name`, `pbiServiceModelId`) must be specified on the `byConnection` object before Power BI Desktop will allow opening a report from a **definition.pbir** file. Otherwise, an error similar to the following will be shown:

![image](https://github.com/user-attachments/assets/e9e23e9b-f036-4a04-a66b-7d81ab87c997)

The example section below the list of properties already includes these properties, but the wording make it sound like only the properties listed are required, so this PR adds the remaining, required, properties to the list.