### PR TITLE
Remove .equals from ISelectionId

### DIFF
--- a/powerbi-docs/developer/visuals/selection-api.md
+++ b/powerbi-docs/developer/visuals/selection-api.md
@@ -20,7 +20,6 @@ The interface corresponds to a `Selection` object:
 
 ```typescript
 export interface ISelectionId {
-    equals(other: ISelectionId): boolean;
     includes(other: ISelectionId, ignoreHighlight?: boolean): boolean;
     getKey(): string;
     getSelector(): Selector;


### PR DESCRIPTION
powerbi.visuals.ISelectionId has .equals() but powerbi.extensibility.ISelectionId does not and powerbi.extensibility.ISelectionId is the correct way to interact with selection ids.

Setup:
```ts
  item.selectionId = this.host.createSelectionIdBuilder()
      .withTable(dataView.table, rowIndex)
      .createSelectionId();
```

Works:
```ts
  const isCurrentlySelected = this.selectionManager.getSelectionIds().some(
      (currentSelectionId) => currentSelectionId === item.selectionId
  );
```

Does not work(error):
```ts
  const isCurrentlySelected = this.selectionManager.getSelectionIds().some(
      (currentSelectionId) => currentSelectionId.equals(item.selectionId)
  );
```

```ts
  const isCurrentlySelected = this.selectionManager.getSelectionIds().some(
      (currentSelectionId) => item.selectionId.equals(currentSelectionId)
  );
```