### PR TITLE
Link to correct version of Report builder

### DIFF
--- a/powerbi-docs/report-server/changelog.md
+++ b/powerbi-docs/report-server/changelog.md
@@ -7,16 +7,19 @@ ms.reviewer: kfollis
 ms.service: powerbi
 ms.subservice: powerbi-report-server
 ms.topic: conceptual
-ms.date: 01/15/2025
+ms.date: 05/14/2025
 ---
 
 # Change log for Power BI Report Server
 
 This change log is for Power BI Report Server and lists new items along with bug fixes for each released build. Always follow the guide on how to [upgrade Power BI Report Server](upgrade.md) when performing any upgrade.
 
-See [What's new in Power BI Report Server](whats-new.md) for more information about new features. For information about Report Builder versions, see the [Power BI Report Builder change log](../paginated-reports/paginated-reports-change-log.md).
+See [What's new in Power BI Report Server](whats-new.md) for more information about new features. 
 
 See [Download Power BI Report Server](download-powerbi-report-server.md) for more information about downloading and installing Power BI Report Server.
+
+You must use Microsoft Report Builder to create paginated reports in Power BI Report Server. For information about Microsoft Report Builder, see [Install Microsoft Report Builder - Power BI Report Server](https://learn.microsoft.com/en-us/power-bi/report-server/install-report-builder).
+
 
 ## January 2025
 


### PR DESCRIPTION
The link to Report Builder is not correct as it takes the user to  Power BI Report Builder's information which is the client for the Power BI service. and that's not the correct client. To create paginated reports for Power BI Report Server the link should take you to Microsoft Report Builder.