### PR TITLE
Template Apps - add 'no support for PBIR'

### DIFF
--- a/powerbi-docs/connect-data/service-template-apps-overview.md
+++ b/powerbi-docs/connect-data/service-template-apps-overview.md
@@ -120,6 +120,7 @@ See [Tips for authoring template apps in Power BI](service-template-apps-tips.md
 | Composite models | Composite models shouldn't be used in the app builder workspace. App installers can use composite models after installing the app. |
 | Large semantic model storage format | Large semantic model storage format isn't supported for template apps. |
 | Mobile layout | Partial support. Mobile layout positioning of elements is supported. Mobile layout changes to other properties, such as color, are not supported. |
+| PBIR enahnced reports | [PowerBI Enahnced Reports format](https://powerbi.microsoft.com/en-us/blog/power-bi-enhanced-report-format-pbir-in-power-bi-desktop-developer-mode-preview/) is not supported. |
 
 ## Support
 

--- a/powerbi-docs/connect-data/service-template-apps-overview.md
+++ b/powerbi-docs/connect-data/service-template-apps-overview.md
@@ -120,7 +120,7 @@ See [Tips for authoring template apps in Power BI](service-template-apps-tips.md
 | Composite models | Composite models shouldn't be used in the app builder workspace. App installers can use composite models after installing the app. |
 | Large semantic model storage format | Large semantic model storage format isn't supported for template apps. |
 | Mobile layout | Partial support. Mobile layout positioning of elements is supported. Mobile layout changes to other properties, such as color, are not supported. |
-| PBIR enahnced reports | [PowerBI Enahnced Reports format](https://powerbi.microsoft.com/en-us/blog/power-bi-enhanced-report-format-pbir-in-power-bi-desktop-developer-mode-preview/) is not supported. |
+| PBIR enhanced reports | [Power BI enhanced report format (PBIR)](https://powerbi.microsoft.com/blog/power-bi-enhanced-report-format-pbir-in-power-bi-desktop-developer-mode-preview/) is not supported. |
 
 ## Support
 


### PR DESCRIPTION
PBIR format (https://powerbi.microsoft.com/en-us/blog/power-bi-enhanced-report-format-pbir-in-power-bi-desktop-developer-mode-preview/)  is not supported by Template Apps.
(The created application is unable to open the report, even if a PBIX is downloaded and the Template App re-created).