### PR TITLE
Update copilot-power-bi-desktop.md

### DIFF
--- a/powerbi-docs/create-reports/copilot-power-bi-desktop.md
+++ b/powerbi-docs/create-reports/copilot-power-bi-desktop.md
@@ -18,6 +18,11 @@ ms.collection: ce-skilling-ai-copilot
 
 To use Copilot in Power BI Desktop, you need admin, member, or contributor access to at least a single workspace that is assigned to a paid Fabric capacity (F64 or higher) or Power BI Premium capacity (P1 or higher) that has Copilot enabled.
 
+> [!IMPORTANT]
+> In addition to capacity-level enablement, Copilot in **Power BI Desktop** also requires that the **tenant-level Fabric Copilot setting is enabled**. If the tenant-level setting is off, the Copilot button will appear in the ribbon but remain disabled.
+>
+> This behavior differs from **Power BI Service**, which checks Copilot availability at the **workspace level**, not the tenant level.
+
 > [!NOTE]
 > The Copilot button in Desktop always appears in the ribbon. To be able to use Copilot, you must be signed in and have access to a workspace that is in Premium or Fabric capacity.
 


### PR DESCRIPTION
> [!IMPORTANT]
> In addition to capacity-level enablement, Copilot in **Power BI Desktop** also requires that the **tenant-level Fabric Copilot setting is enabled**. If the tenant-level setting is off, the Copilot button will appear in the ribbon but remain disabled.
>
> This behavior differs from **Power BI Service**, which checks Copilot availability at the **workspace level**, not the tenant level.