### PR TITLE
Update service-admin-auditing.md

### DIFF
--- a/powerbi-docs/enterprise/service-admin-auditing.md
+++ b/powerbi-docs/enterprise/service-admin-auditing.md
@@ -28,6 +28,8 @@ You can track Microsoft Fabric user activities, including Power BI operations, u
 
 The Power BI activity log contains complete copy of the Power BI activities in a JSON array. You can find a list of all the Power BI activities in the Fabric [operation list](/fabric/admin/operation-list).
 
+Most audit events show up within 30 minutes, however, there can be a lag of up to 60 minutes to retrieve Power BI events.  For details on SLAs for Purview audit logs, please visit [Microsoft Purview documentation](https://aka.ms/PurviewAuditSearch).
+
 ### ActivityEvents REST API
 
 You can use an administrative application based on the Power BI REST APIs to export activity events into a blob store or SQL database. You can then build a custom usage report on top of the exported data. In the **ActivityEvents** REST API call, you must specify a start date and end date and optionally a filter to select activities by activity type or user ID. Because the activity log could contain a large amount of data, the **ActivityEvents** API currently only supports downloading up to one day of data per request. In other words, the start date and end date must specify the same day, as in the following example. Make sure you specify the `DateTime` values in Coordinated Universal Time (UTC) format.


### PR DESCRIPTION
Some customers depend on these 30 min SLAs and we need public docs to state this in order to restore customer confidence in auditing / reactive monitoring. 

Several customers made the decision to go with reactive monitoring based on originally published 30 min SLA which we subsequently pulled from docs. Purview doc doesn’t list Fabric/Power BI as core service explicitly. This poses the risk of not detecting desired activity in expected by customers timeframe and will reduce their confidence in our logs.